### PR TITLE
Remove working directory substring from filename of pmd violation

### DIFF
--- a/lib/pmdtester/builders/diff_builder.rb
+++ b/lib/pmdtester/builders/diff_builder.rb
@@ -14,17 +14,19 @@ module PmdTester
     # http://pmd.sourceforge.net/report_2_0_0.xsd
     def build(base_report_filename, patch_report_filename, base_info, patch_info, filter_set = nil)
       report_diffs = ReportDiff.new
-      base_violations, base_errors = parse_pmd_report(base_report_filename, 'base', filter_set)
-      patch_violations, patch_errors = parse_pmd_report(patch_report_filename, 'patch')
+      base_details, patch_details = report_diffs.calculate_details(base_info, patch_info)
+      base_violations, base_errors = parse_pmd_report(base_report_filename, 'base',
+                                                      base_details.working_dir, filter_set)
+      patch_violations, patch_errors = parse_pmd_report(patch_report_filename, 'patch',
+                                                        patch_details.working_dir)
       report_diffs.calculate_violations(base_violations, patch_violations)
       report_diffs.calculate_errors(base_errors, patch_errors)
-      report_diffs.calculate_details(base_info, patch_info)
 
       report_diffs
     end
 
-    def parse_pmd_report(report_filename, branch, filter_set = nil)
-      doc = PmdReportDocument.new(branch, filter_set)
+    def parse_pmd_report(report_filename, branch, working_dir, filter_set = nil)
+      doc = PmdReportDocument.new(branch, working_dir, filter_set)
       parser = Nokogiri::XML::SAX::Parser.new(doc)
       parser.parse_file(report_filename) unless report_filename.nil?
       [doc.violations, doc.errors]

--- a/lib/pmdtester/parsers/pmd_report_document.rb
+++ b/lib/pmdtester/parsers/pmd_report_document.rb
@@ -40,7 +40,7 @@ module PmdTester
     end
 
     def remove_work_dir!(str)
-      str.sub!(/^#{@working_dir}/, '')
+      str.sub!(/#{@working_dir}/, '')
     end
 
     def characters(string)
@@ -65,6 +65,7 @@ module PmdTester
     end
 
     def cdata_block(string)
+      remove_work_dir!(string)
       @current_error.text = string unless @current_error.nil?
     end
 

--- a/lib/pmdtester/parsers/pmd_report_document.rb
+++ b/lib/pmdtester/parsers/pmd_report_document.rb
@@ -9,7 +9,7 @@ module PmdTester
   class PmdReportDocument < Nokogiri::XML::SAX::Document
     attr_reader :violations
     attr_reader :errors
-    def initialize(branch_name, filter_set = nil)
+    def initialize(branch_name, working_dir, filter_set = nil)
       @violations = PmdViolations.new
       @errors = PmdErrors.new
       @current_violations = []
@@ -18,6 +18,7 @@ module PmdTester
       @current_element = ''
       @filename = ''
       @filter_set = filter_set
+      @working_dir = working_dir
       @branch_name = branch_name
     end
 
@@ -28,11 +29,11 @@ module PmdTester
       case name
       when 'file'
         @current_violations = []
-        @current_filename = attrs['name']
+        @current_filename = attrs['name'].sub(/^#{@working_dir}/, '')
       when 'violation'
         @current_violation = PmdViolation.new(attrs, @branch_name)
       when 'error'
-        @current_filename = attrs['filename']
+        @current_filename = attrs['filename'].sub(/^#{@working_dir}/, '')
         @current_error = PmdError.new(attrs, @branch_name)
       end
     end

--- a/lib/pmdtester/parsers/pmd_report_document.rb
+++ b/lib/pmdtester/parsers/pmd_report_document.rb
@@ -29,13 +29,18 @@ module PmdTester
       case name
       when 'file'
         @current_violations = []
-        @current_filename = attrs['name'].sub(/^#{@working_dir}/, '')
+        @current_filename = remove_work_dir!(attrs['name'])
       when 'violation'
         @current_violation = PmdViolation.new(attrs, @branch_name)
       when 'error'
-        @current_filename = attrs['filename'].sub(/^#{@working_dir}/, '')
+        @current_filename = remove_work_dir!(attrs['filename'])
+        remove_work_dir!(attrs['msg'])
         @current_error = PmdError.new(attrs, @branch_name)
       end
+    end
+
+    def remove_work_dir!(str)
+      str.sub!(/^#{@working_dir}/, '')
     end
 
     def characters(string)

--- a/lib/pmdtester/pmd_report_detail.rb
+++ b/lib/pmdtester/pmd_report_detail.rb
@@ -7,14 +7,16 @@ module PmdTester
   class PmdReportDetail
     attr_accessor :execution_time
     attr_accessor :timestamp
+    attr_reader :working_dir
 
     def initialize
       @execution_time = 0
       @timestamp = ''
+      @working_dir = Dir.getwd
     end
 
     def save(report_info_path)
-      hash = { execution_time: @execution_time, timestamp: @timestamp }
+      hash = { execution_time: @execution_time, timestamp: @timestamp, working_dir: @working_dir }
       file = File.new(report_info_path, 'w')
       file.puts JSON.generate(hash)
       file.close
@@ -25,6 +27,7 @@ module PmdTester
         hash = JSON.parse(File.read(report_info_path))
         @execution_time = hash['execution_time']
         @timestamp = hash['timestamp']
+        @working_dir = hash['working_dir']
         hash
       else
         puts "#{report_info_path} doesn't exist"

--- a/lib/pmdtester/project.rb
+++ b/lib/pmdtester/project.rb
@@ -51,13 +51,13 @@ module PmdTester
     # Change the file path from 'LOCAL_DIR/SOURCE_CODE_PATH' to
     # 'WEB_VIEW_URL/SOURCE_CODE_PATH'
     def get_webview_url(file_path)
-      file_path.gsub(/#{local_source_path}/, @webview_url)
+      file_path.gsub(%r{/#{local_source_path}}, @webview_url)
     end
 
     # Change the file path from 'LOCAL_DIR/SOURCE_CODE_PATH' to
     # 'PROJECT_NAME/SOURCE_CODE_PATH'
     def get_path_inside_project(file_path)
-      file_path.gsub(/#{local_source_path}/, @name)
+      file_path.gsub(%r{/#{local_source_path}}, @name)
     end
 
     def get_pmd_report_path(branch_name)
@@ -84,7 +84,7 @@ module PmdTester
     end
 
     def local_source_path
-      "#{Dir.getwd}/#{REPOSITORIES_PATH}/#{@name}"
+      "#{REPOSITORIES_PATH}/#{@name}"
     end
 
     def target_diff_report_path

--- a/lib/pmdtester/report_diff.rb
+++ b/lib/pmdtester/report_diff.rb
@@ -77,6 +77,7 @@ module PmdTester
 
       @base_timestamp = base_details.timestamp
       @patch_timestamp = patch_details.timestamp
+      [base_details, patch_details]
     end
 
     def build_diffs(base_hash, patch_hash)

--- a/test/integration_test_runner.rb
+++ b/test/integration_test_runner.rb
@@ -39,14 +39,15 @@ class IntegrationTestRunner < Test::Unit::TestCase
   end
 
   def test_online_mode
-    argv = '-r target/repositories/pmd -m online -b test_branch -p pmd_releases/6.3.0'
+    base_branch = 'test_branch_2'
+    argv = "-r target/repositories/pmd -m online -b #{base_branch} -p pmd_releases/6.3.0"
     # This test depends on the file test_branch-baseline.zip being available on sourceforge.
 
     system("bundle exec bin/pmdtester #{argv}")
 
-    assert_path_exist('target/reports/test_branch-baseline.zip')
-    assert_path_exist('target/reports/test_branch/checkstyle/pmd_report.xml')
-    assert_path_exist('target/reports/test_branch/spring-framework/pmd_report.xml')
+    assert_path_exist("target/reports/#{base_branch}-baseline.zip")
+    assert_path_exist("target/reports/#{base_branch}/checkstyle/pmd_report.xml")
+    assert_path_exist("target/reports/#{base_branch}/spring-framework/pmd_report.xml")
     assert_path_exist('target/reports/pmd_releases_6.3.0/checkstyle/pmd_report.xml')
     assert_path_exist('target/reports/pmd_releases_6.3.0/spring-framework/pmd_report.xml')
     assert_path_exist('target/reports/diff/checkstyle/index.html')

--- a/test/resources/diff_builder/base_report_info.json
+++ b/test/resources/diff_builder/base_report_info.json
@@ -1,0 +1,1 @@
+{"execution_time":121,"timestamp":"base time stamp","working_dir":""}

--- a/test/resources/diff_builder/patch_report_info.json
+++ b/test/resources/diff_builder/patch_report_info.json
@@ -1,0 +1,1 @@
+{"execution_time":65,"timestamp":"patch time stamp","working_dir":""}

--- a/test/resources/html_report_builder/base_report_info.json
+++ b/test/resources/html_report_builder/base_report_info.json
@@ -1,1 +1,1 @@
-{"execution_time":121,"timestamp":"base time stamp"}
+{"execution_time":121,"timestamp":"base time stamp","working_dir":"SHOULD_BE_REPLACED"}

--- a/test/resources/html_report_builder/patch_report_info.json
+++ b/test/resources/html_report_builder/patch_report_info.json
@@ -1,1 +1,1 @@
-{"execution_time":65,"timestamp":"patch time stamp"}
+{"execution_time":65,"timestamp":"patch time stamp","working_dir":"SHOULD_BE_REPLACED"}

--- a/test/test_diff_builder.rb
+++ b/test/test_diff_builder.rb
@@ -7,8 +7,8 @@ require_relative '../lib/pmdtester/builders/diff_report_builder'
 # Unit test class for PmdTester::DiffBuilder
 class TestDiffBuilder < Test::Unit::TestCase
   include PmdTester
-  BASE_REPORT_INFO_PATH = 'test/resources/html_report_builder/base_report_info.json'
-  PATCH_REPORT_INFO_PATH = 'test/resources/html_report_builder/patch_report_info.json'
+  BASE_REPORT_INFO_PATH = 'test/resources/diff_builder/base_report_info.json'
+  PATCH_REPORT_INFO_PATH = 'test/resources/diff_builder/patch_report_info.json'
 
   def setup
     `rake clean`

--- a/test/test_diff_report_builder.rb
+++ b/test/test_diff_report_builder.rb
@@ -7,14 +7,10 @@ require_relative '../lib/pmdtester/parsers/projects_parser'
 
 # Unit test class for PmdTester::DiffReportBuilder
 class TestDiffReportBuilder < Test::Unit::TestCase
-  ORIGINAL_BASE_PMD_REPORT_PATH =
+  BASE_PMD_REPORT_PATH =
     'test/resources/html_report_builder/test_html_report_builder_base.xml'
-  ORIGINAL_PATCH_PMD_REPORT_PATH =
+  PATCH_PMD_REPORT_PATH =
     'test/resources/html_report_builder/test_html_report_builder_patch.xml'
-
-  TARGET_TEST_RESOURCES_PATH = 'target/test/resources'
-  BASE_PMD_REPORT_PATH = "#{TARGET_TEST_RESOURCES_PATH}/test_html_report_builder_base.xml"
-  PATCH_PMD_REPORT_PATH = "#{TARGET_TEST_RESOURCES_PATH}/test_html_report_builder_patch.xml"
 
   BASE_REPORT_INFO_PATH = 'test/resources/html_report_builder/base_report_info.json'
   PATCH_REPORT_INFO_PATH = 'test/resources/html_report_builder/patch_report_info.json'
@@ -24,16 +20,7 @@ class TestDiffReportBuilder < Test::Unit::TestCase
   EXPECTED_EMPTY_REPORT_PATH =
     'test/resources/html_report_builder/expected_empty_diff_report.html'
   def setup
-    # `rake clean`
-  end
-
-  def build_pmd_report(original_filename, build_filename)
-    FileUtils.mkdir_p(TARGET_TEST_RESOURCES_PATH) unless File.directory?(TARGET_TEST_RESOURCES_PATH)
-    File.open(build_filename, 'w') do |build_file|
-      File.open(original_filename, 'r') do |file|
-        build_file.write file.read.gsub(/SHOULD_BE_REPLACED/, Dir.getwd)
-      end
-    end
+    `rake clean`
   end
 
   def test_diff_report_builder
@@ -42,9 +29,6 @@ class TestDiffReportBuilder < Test::Unit::TestCase
 
     actual_report_path = "target/reports/diff/#{project.name}"
     css_path = "#{actual_report_path}/css"
-
-    build_pmd_report(ORIGINAL_BASE_PMD_REPORT_PATH, BASE_PMD_REPORT_PATH)
-    build_pmd_report(ORIGINAL_PATCH_PMD_REPORT_PATH, PATCH_PMD_REPORT_PATH)
 
     diff_builder = PmdTester::DiffBuilder.new
     project.report_diff = diff_builder.build(BASE_PMD_REPORT_PATH, PATCH_PMD_REPORT_PATH,

--- a/test/test_pmd_report_detail.rb
+++ b/test/test_pmd_report_detail.rb
@@ -19,5 +19,6 @@ class TestPmdReportDetail < Test::Unit::TestCase
     assert_equal(121, hash['execution_time'])
     assert_equal('timestamp', hash['timestamp'])
     assert_equal('00:02:01', details.format_execution_time)
+    assert_equal(Dir.getwd, hash['working_dir'])
   end
 end

--- a/test/test_pmd_report_document.rb
+++ b/test/test_pmd_report_document.rb
@@ -8,7 +8,7 @@ require_relative '../lib/pmdtester/parsers/pmd_report_document'
 class TestPmdReportDocument < Test::Unit::TestCase
   include PmdTester
   def test_document
-    doc = PmdReportDocument.new('base')
+    doc = PmdReportDocument.new('base', 'SHOULD_BE_REPLACED')
     parser = Nokogiri::XML::SAX::Parser.new(doc)
     parser.parse(File.open('test/resources/pmd_report_document/test_document.xml'))
     assert_equal(8, doc.violations.violations_size)
@@ -19,7 +19,7 @@ class TestPmdReportDocument < Test::Unit::TestCase
 
   def test_filter_set
     filter_set = Set['documentation']
-    doc = PmdReportDocument.new('base', filter_set)
+    doc = PmdReportDocument.new('base', 'SHOULD_BE_REPLACED', filter_set)
     parser = Nokogiri::XML::SAX::Parser.new(doc)
     parser.parse(File.open('test/resources/pmd_report_document/test_document.xml'))
     assert_equal(1, doc.violations.violations_size)


### PR DESCRIPTION
When we generate the baseline which will be uploaded to somewhere, the file attribute of the violation element in the pmd report contains the local working path information. The baseline is used for sharing, so we should remove this part of the information.