### PR TITLE
Release pmdtester 1.0.0.beta1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ Gemfile.lock
 .project
 .idea
 .bundle
+pmdtester.gemspec
 target/
 vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: ruby
 jdk: oraclejdk9
 script:
-  - rake rubocop
-  - rake clean test
-  - rake clean integration-test
-  - rake install_gem
-  - pmdtester -h
+- rake rubocop
+- rake clean test
+- rake clean integration-test
+- rake install_gem
+- pmdtester -h
+
+before_deploy: "rake hoe:spec"
+deploy:
+  provider: rubygems
+  api_key:
+    secure: xcEpX/r7es6/jnvNPrVClVkKLemC+4EaFACfK9PCw05jAqf3sDX8UMKD2B4NU1JfF+I/szC5loyCe8s1wBUbFhelR8sL93RNOyVlQCKqaDTFw0DUvnbKWdgDb7POhcmo8SWi4aaKPias6wCuWA/Wc6jUvcrlAgKDsmYqOukXQoFyQbOUsnqrE/FMA7BfUIHkeeJbNk8807u4+aMqahZyzTFvuEVBUvKqCzDYPl9kpm4fzOtjxiExj1ic9dr2Dz5bcyWteMjZFSgjYWgZUXpk8FWCj5R/8VQsklxFFXFZlQIVwqtpaKgEOjwOOxaA6b8O7OeU82HtSPfxy6eCNE7pvzoYq+ZGxxk6fPbAl2mqKtPU76oRKH8YmXuEdDtdHVCYp7wOFdrLhJ6bJ3H/DSD14Kso21D3ktt4y4qkCd0Ev1a6nbY3LrO+NqFlZytwlYY1t8CUWyc9GfvpQXd7j0shSvrh2RU0+ATcQc0tRSHE2htjbiMWPi/ffMNe5h7iVqho5cLC4n187VrWOqGJf2S47spIgw9N3VWzyfAxAxI2XIvWcGoAIQhEgU6bH14Mz+0amG6ggzCBAbDPEC1j8cuwVkmanWCWZWi6EuRbCYZ7rgCFIx3hZS9NPBANfcXudm7eINvuMlFnmwrVzmtTIEZTy56ZfaWPzGxotyn5M9DdT1U=
+  on:
+    tags: true
+  gem: pmdtester
+  gemspec: pmdtester.gemspec

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -11,9 +11,7 @@ bin/pmdtester
 config/all-java.xml
 config/design.xml
 config/project-list.xml
-config/project_list.txt
 config/projectlist_1_0_0.xsd
-lib/pmdtester/pmdtester.rb
 lib/pmdtester/builders/diff_builder.rb
 lib/pmdtester/builders/diff_report_builder.rb
 lib/pmdtester/builders/html_report_builder.rb
@@ -28,6 +26,7 @@ lib/pmdtester/pmd_branch_detail.rb
 lib/pmdtester/pmd_error.rb
 lib/pmdtester/pmd_report_detail.rb
 lib/pmdtester/pmd_violation.rb
+lib/pmdtester/pmdtester.rb
 lib/pmdtester/project.rb
 lib/pmdtester/report_diff.rb
 lib/pmdtester/resource_locator.rb

--- a/Rakefile
+++ b/Rakefile
@@ -11,10 +11,11 @@ Hoe.plugin :bundler
 Hoe.plugin :gemspec
 Hoe.plugin :git
 
-Hoe.spec 'pmdtester' do
+hoe = Hoe.spec 'pmdtester' do
   self.version = PmdTester::Options::VERSION
 
-  self.author  = 'Binguo Bao'
+  developer 'Andreas Dangel', 'andreas.dangel@adangel.org'
+  developer 'Binguo Bao', 'djydewang@gmail.com'
   self.email   = 'djydewang@gmail.com'
   self.clean_globs = %w[target/reports/**/* target/test/**/*]
   self.extra_deps += [['nokogiri', '~> 1.8.2'], ['slop', '~> 4.6.2']]
@@ -43,6 +44,11 @@ Rake::TestTask.new('integration-test') do |task|
   task.libs = ['test']
   task.pattern = 'test/**/integration_test_*.rb'
   task.verbose = true
+end
+
+desc 'generate the pmdtester.gemspec file'
+task 'hoe:spec' do
+  File.open("#{hoe.name}.gemspec", "w") { |f| f.write hoe.spec.to_ruby}
 end
 
 # vim: syntax=ruby

--- a/config/project_list.txt
+++ b/config/project_list.txt
@@ -1,5 +1,0 @@
-# The standard projects list
-# Format:
-# REPOSITORY_NAME|[git|hg]|REPOSITORY_URI|[COMMIT_ID]|[EXCLUDE PATTERN]
-
-spring-framework|git|https://github.com/spring-projects/spring-framework|||

--- a/lib/pmdtester/parsers/options.rb
+++ b/lib/pmdtester/parsers/options.rb
@@ -15,7 +15,7 @@ module PmdTester
     LOCAL = 'local'
     ONLINE = 'online'
     SINGLE = 'single'
-    VERSION = '1.0.0-SNAPSHOT'
+    VERSION = '1.0.0.beta1'
 
     attr_reader :local_git_repo
     attr_reader :base_branch


### PR DESCRIPTION
- Adding a rake task named `hoe:spec` which can genenrate a gemspec based on a Hoe spec.

- Configuring travis CI's RubyGems Deployment
