### PR TITLE
Fix color scheme for diff report, add default values for various options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,11 @@ AllCops:
 
 Metrics/LineLength:
   Max: 100
+
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/pmdtester/parsers/options.rb'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'lib/pmdtester/parsers/options.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ hoe = Hoe.spec 'pmdtester' do
     ['rubocop',       '~> 0.56.0'],
     ['test-unit',     '~> 3.2.3']
   ]
+  self.spec_extras[:required_rubygems_version] = '>= 2.4.1'
 
   license 'BSD-2-Clause'
 end

--- a/lib/pmdtester/builders/diff_report_builder.rb
+++ b/lib/pmdtester/builders/diff_report_builder.rb
@@ -73,8 +73,8 @@ module PmdTester
     def build_summary_row(doc, item, base, patch, diff)
       doc.tr do
         doc.td(class: 'c') { doc.text item }
-        doc.td(class: 'a') { doc.text base }
-        doc.td(class: 'b') { doc.text patch }
+        doc.td(class: 'b') { doc.text base }
+        doc.td(class: 'a') { doc.text patch }
         doc.td(class: 'c') { doc.text diff }
       end
     end
@@ -131,7 +131,7 @@ module PmdTester
     end
 
     def build_violation_table_row(doc, key, pmd_violation, a_index)
-      doc.tr(class: pmd_violation.branch == 'base' ? 'a' : 'b') do
+      doc.tr(class: pmd_violation.branch == 'base' ? 'b' : 'a') do
         # The anchor
         doc.td do
           doc.a(id: "A#{a_index}", href: "#A#{a_index}") { doc.text '#' }
@@ -204,7 +204,7 @@ module PmdTester
       doc.tbody do
         b_index = 1
         errors.each do |pmd_error|
-          doc.tr(class: pmd_error.branch == 'base' ? 'a' : 'b') do
+          doc.tr(class: pmd_error.branch == 'base' ? 'b' : 'a') do
             # The anchor
             doc.td do
               doc.a(id: "B#{b_index}", href: "#B#{b_index}") { doc.text '#' }

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -97,7 +97,7 @@ module PmdTester
 
       sum_time = 0
       @projects.each do |project|
-        logger.info "Generating #{project.name}'s PMD report'"
+        logger.info "Generating #{project.name}'s PMD report"
         execution_time, end_time =
           generate_pmd_report(project.local_source_path,
                               project.get_pmd_report_path(@pmd_branch_name))

--- a/lib/pmdtester/parsers/options.rb
+++ b/lib/pmdtester/parsers/options.rb
@@ -14,6 +14,8 @@ module PmdTester
     LOCAL = 'local'
     ONLINE = 'online'
     SINGLE = 'single'
+    DEFAULT_CONFIG_PATH = ResourceLocator.locate('config/all-java.xml')
+    DEFAULT_LIST_PATH = ResourceLocator.locate('config/project-list.xml')
 
     attr_reader :local_git_repo
     attr_reader :base_branch
@@ -68,11 +70,14 @@ module PmdTester
         o.string '-b', '--base-branch', 'name of the base branch in local PMD repository'
         o.string '-p', '--patch-branch',
                  'name of the patch branch in local PMD repository'
-        o.string '-bc', '--base-config', 'path to the base PMD configuration file'
-        o.string '-pc', '--patch-config', 'path to the patch PMD configuration file'
+        o.string '-bc', '--base-config', 'path to the base PMD configuration file',
+                 default: DEFAULT_CONFIG_PATH
+        o.string '-pc', '--patch-config', 'path to the patch PMD configuration file',
+                 default: DEFAULT_CONFIG_PATH
         o.string '-c', '--config', 'path to the base and patch PMD configuration file'
         o.string '-l', '--list-of-project',
-                 'path to the file which contains the list of standard projects'
+                 'path to the file which contains the list of standard projects',
+                 default: DEFAULT_LIST_PATH
         o.string '-m', '--mode', mode_message, default: 'local'
         o.bool '-f', '--html-flag',
                'whether to not generate the html diff report in single mode'
@@ -111,20 +116,17 @@ module PmdTester
     def check_local_options
       check_option(LOCAL, 'base branch name', @base_branch)
       check_option(LOCAL, 'base branch config path', @base_config) unless @auto_config_flag
-      check_option(LOCAL, 'patch branch name', @patch_branch)
       check_option(LOCAL, 'patch branch config path', @patch_config) unless @auto_config_flag
       check_option(LOCAL, 'list of projects file path', @project_list)
     end
 
     def check_single_options
-      check_option(SINGLE, 'patch branch name', @patch_branch)
       check_option(SINGLE, 'patch branch config path', @patch_config)
       check_option(SINGLE, 'list of projects file path', @project_list)
     end
 
     def check_online_options
       check_option(ONLINE, 'base branch name', @base_branch)
-      check_option(ONLINE, 'patch branch name', @patch_branch)
     end
 
     def check_common_options

--- a/lib/pmdtester/runner.rb
+++ b/lib/pmdtester/runner.rb
@@ -18,6 +18,7 @@ module PmdTester
       when Options::SINGLE
         run_single_mode
       end
+      introduce_new_pmd_error?
     end
 
     def run_local_mode
@@ -115,6 +116,13 @@ module PmdTester
 
     def get_projects(file_path)
       @projects = ProjectsParser.new.parse(file_path)
+    end
+
+    def introduce_new_pmd_error?
+      @projects.each do |project|
+        return true if project.introduce_new_errors?
+      end
+      false
     end
   end
 end

--- a/test/resources/html_report_builder/expected_diff_report_index.html
+++ b/test/resources/html_report_builder/expected_diff_report_index.html
@@ -17,26 +17,26 @@
 <tbody>
 <tr>
 <td class="c">number of errors</td>
-<td class="a">0</td>
-<td class="b">1</td>
+<td class="b">0</td>
+<td class="a">1</td>
 <td class="c">1</td>
 </tr>
 <tr>
 <td class="c">number of violations</td>
-<td class="a">5</td>
-<td class="b">8</td>
+<td class="b">5</td>
+<td class="a">8</td>
 <td class="c">7</td>
 </tr>
 <tr>
 <td class="c">execution time</td>
-<td class="a">00:02:01</td>
-<td class="b">00:01:05</td>
+<td class="b">00:02:01</td>
+<td class="a">00:01:05</td>
 <td class="c">00:00:56</td>
 </tr>
 <tr>
 <td class="c">timestamp</td>
-<td class="a">base time stamp</td>
-<td class="b">patch time stamp</td>
+<td class="b">base time stamp</td>
+<td class="a">patch time stamp</td>
 <td class="c"></td>
 </tr>
 </tbody>
@@ -54,7 +54,7 @@
 <th>Message</th>
 <th>Line</th>
 </tr></thead>
-<tbody><tr class="a">
+<tbody><tr class="b">
 <td><a id="A1" href="#A1">#</a></td>
 <td>3</td>
 <td><a href="http://pmd.sourceforge.net/snapshot/pmd_rules_java_codestyle.html#fielddeclarationsshouldbeatstartofclass">FieldDeclarationsShouldBeAtStartOfClass</a></td>
@@ -76,7 +76,7 @@ Fields should be declared at the top of the class, before any method declaration
 <th>Line</th>
 </tr></thead>
 <tbody>
-<tr class="a">
+<tr class="b">
 <td><a id="A1" href="#A1">#</a></td>
 <td>3</td>
 <td><a href="http://pmd.sourceforge.net/snapshot/pmd_rules_java_design.html#godclass">GodClass</a></td>
@@ -85,7 +85,7 @@ Possible God Class (WMC=101, ATFD=29, TCC=3.374%)
 </td>
 <td><a href="https://github.com/spring-projects/spring-framework/tree/v5.0.6.RELEASE/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java#L63">63</a></td>
 </tr>
-<tr class="b">
+<tr class="a">
 <td><a id="A2" href="#A2">#</a></td>
 <td>3</td>
 <td><a href="http://pmd.sourceforge.net/snapshot/pmd_rules_java_design.html#godclass">GodClass</a></td>
@@ -94,7 +94,7 @@ Possible God Class (WMC=101, ATFD=29, TCC=4.000%)
 </td>
 <td><a href="https://github.com/spring-projects/spring-framework/tree/v5.0.6.RELEASE/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java#L63">63</a></td>
 </tr>
-<tr class="b">
+<tr class="a">
 <td><a id="A3" href="#A3">#</a></td>
 <td>3</td>
 <td><a href="http://pmd.sourceforge.net/snapshot/pmd_rules_java_codestyle.html#fielddeclarationsshouldbeatstartofclass">FieldDeclarationsShouldBeAtStartOfClass</a></td>
@@ -116,7 +116,7 @@ Fields should be declared at the top of the class, before any method declaration
 <th>Message</th>
 <th>Line</th>
 </tr></thead>
-<tbody><tr class="b">
+<tbody><tr class="a">
 <td><a id="A1" href="#A1">#</a></td>
 <td>3</td>
 <td><a href="http://pmd.sourceforge.net/snapshot/pmd_rules_java_codestyle.html#fielddeclarationsshouldbeatstartofclass">FieldDeclarationsShouldBeAtStartOfClass</a></td>
@@ -137,7 +137,7 @@ Fields should be declared at the top of the class, before any method declaration
 <th>Message</th>
 <th>Line</th>
 </tr></thead>
-<tbody><tr class="b">
+<tbody><tr class="a">
 <td><a id="A1" href="#A1">#</a></td>
 <td>3</td>
 <td><a href="http://pmd.sourceforge.net/snapshot/pmd_rules_java_codestyle.html#fielddeclarationsshouldbeatstartofclass">FieldDeclarationsShouldBeAtStartOfClass</a></td>
@@ -158,7 +158,7 @@ Fields should be declared at the top of the class, before any method declaration
 <th>Message</th>
 <th>Line</th>
 </tr></thead>
-<tbody><tr class="b">
+<tbody><tr class="a">
 <td><a id="A1" href="#A1">#</a></td>
 <td>1</td>
 <td><a href="http://pmd.sourceforge.net/snapshot/pmd_rules_java_design.html#classwithonlyprivateconstructorsshouldbefinal">ClassWithOnlyPrivateConstructorsShouldBeFinal</a></td>
@@ -180,7 +180,7 @@ A class which only has private constructors should be final
 <th>Message</th>
 <th>Details</th>
 </tr></thead>
-<tbody><tr class="b">
+<tbody><tr class="a">
 <td><a id="B1" href="#B1">#</a></td>
 <td>This is an artificial error message.</td>
 <td></td>

--- a/test/resources/html_report_builder/expected_empty_diff_report.html
+++ b/test/resources/html_report_builder/expected_empty_diff_report.html
@@ -17,26 +17,26 @@
 <tbody>
 <tr>
 <td class="c">number of errors</td>
-<td class="a">0</td>
 <td class="b">0</td>
+<td class="a">0</td>
 <td class="c">0</td>
 </tr>
 <tr>
 <td class="c">number of violations</td>
-<td class="a">0</td>
 <td class="b">0</td>
+<td class="a">0</td>
 <td class="c">0</td>
 </tr>
 <tr>
 <td class="c">execution time</td>
-<td class="a">0</td>
 <td class="b">0</td>
+<td class="a">0</td>
 <td class="c">0</td>
 </tr>
 <tr>
 <td class="c">timestamp</td>
-<td class="a"></td>
 <td class="b"></td>
+<td class="a"></td>
 <td class="c"></td>
 </tr>
 </tbody>

--- a/test/test_options.rb
+++ b/test/test_options.rb
@@ -30,6 +30,14 @@ class TestOptions < Test::Unit::TestCase
     assert_equal('config/project_list.txt', opts.project_list)
   end
 
+  def test_default_value
+    command_line = %w[-r /path/to/repo -b pmd_releases/6.2.0 -p master]
+    opts = Options.new(command_line)
+    assert_equal(Options::DEFAULT_CONFIG_PATH, opts.base_config)
+    assert_equal(Options::DEFAULT_CONFIG_PATH, opts.patch_config)
+    assert_equal(Options::DEFAULT_LIST_PATH, opts.project_list)
+  end
+
   def test_single_mode
     command_line =
       %w[-r /path/to/repo -p master -pc config.xml -l list.xml -f -m single]
@@ -59,27 +67,6 @@ class TestOptions < Test::Unit::TestCase
     argv = %w[-r target/repositories/pmd -bc config/design.xml
               -p pmd_releases/6.1.0 -pc config/design.xml -l test/resources/project-test.xml]
     expect = 'base branch name is required in local mode.'
-    parse_and_assert_error_messages(argv, expect)
-  end
-
-  def test_local_miss_base_config
-    argv = %w[-r target/repositories/pmd -b master
-              -p pmd_releases/6.1.0 -pc config/design.xml -l test/resources/project-test.xml]
-    expect = 'base branch config path is required in local mode.'
-    parse_and_assert_error_messages(argv, expect)
-  end
-
-  def test_local_miss_patch_config
-    argv = %w[-r target/repositories/pmd -bc config/design.xml
-              -p pmd_releases/6.1.0 -l test/resources/project-test.xml]
-    expect = 'base branch name is required in local mode.'
-    parse_and_assert_error_messages(argv, expect)
-  end
-
-  def test_single_miss_patch_config
-    argv = %w[-r target/repositories/pmd -m single
-              -p pmd_releases/6.1.0 -l test/resources/project-test.xml]
-    expect = 'patch branch config path is required in single mode.'
     parse_and_assert_error_messages(argv, expect)
   end
 

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -10,6 +10,12 @@ class TestRunner < Test::Unit::TestCase
 
   include PmdTester
 
+  def run_runner(argv)
+    runner = Runner.new(argv)
+    runner.expects(:introduce_new_pmd_error?).returns(true)
+    runner.run
+  end
+
   def test_single_mode
     PmdReportBuilder.any_instance.stubs(:build)
                     .returns(PmdBranchDetail.new('test_branch')).once
@@ -20,7 +26,7 @@ class TestRunner < Test::Unit::TestCase
 
     argv = %w[-r target/repositories/pmd -p pmd_releases/6.1.0
               -pc config/design.xml -l test/resources/project-test.xml -m single]
-    Runner.new(argv).run
+    run_runner(argv)
   end
 
   def test_local_mode
@@ -31,6 +37,6 @@ class TestRunner < Test::Unit::TestCase
 
     argv = %w[-r target/repositories/pmd -b master -bc config/design.xml -p pmd_releases/6.1.0
               -pc config/design.xml -l test/resources/project-test.xml]
-    Runner.new(argv).run
+    run_runner(argv)
   end
 end


### PR DESCRIPTION
- Fixing color scheme of the the diff report
- Adding default values to the option: `base_config`, `patch_config`, `list_of_project`