### PR TITLE
Ignore changes to test code of PMD when generating dynamic rule sets

### DIFF
--- a/lib/pmdtester/builders/rule_set_builder.rb
+++ b/lib/pmdtester/builders/rule_set_builder.rb
@@ -46,7 +46,7 @@ module PmdTester
         base = @options.base_branch
         patch = @options.patch_branch
         # We only need to support git here, since PMD's repo is using git.
-        diff_cmd = "git diff --name-only #{base}..#{patch} -- pmd-core pmd-java"
+        diff_cmd = "git diff --name-only #{base}..#{patch} -- pmd-core/src/main pmd-java/src/main"
         filenames = Cmd.execute(diff_cmd)
       end
       filenames.split("\n")

--- a/lib/pmdtester/cmd.rb
+++ b/lib/pmdtester/cmd.rb
@@ -13,6 +13,7 @@ module PmdTester
 
       logger.debug stdout
       unless status.success?
+        logger.error stdout
         logger.error stderr
         raise CmdException.new(cmd, stderr)
       end


### PR DESCRIPTION
The behavior of pmdtester in https://github.com/pmd/pmd/pull/1280 is not expected. The dynamic rule set of the patch branch should only contain the bestpratices rule set instead of the all java rules.
In addition, danger should comment that no java rules are changed in https://github.com/pmd/pmd/pull/1282 rather than provide the diff report link. The above issues are caused by not filtering the test code of pmd when generating the dynamic rule set. Please help me check if I still have something left :smile: 