### PR TITLE
Removes the exit statement in RuleSetBuilder Class

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,9 +26,10 @@ hoe = Hoe.spec 'pmdtester' do
     ['mocha',         '~> 1.5.0'],
     # use the same version of rubocop as codacy
     ['rubocop',       '~> 0.51.0'],
-    ['test-unit',     '~> 3.2.3']
+    ['test-unit',     '~> 3.2.3'],
+    ['rdoc',          ['>= 4.0', '< 7']]
   ]
-  spec_extras[:required_rubygems_version] = '>= 2.4.1'
+  spec_extras[:required_rubygems_version] = '>= 2.7.6'
 
   license 'BSD-2-Clause'
 end

--- a/lib/pmdtester/builders/rule_set_builder.rb
+++ b/lib/pmdtester/builders/rule_set_builder.rb
@@ -29,6 +29,7 @@ module PmdTester
       output_filter_set(rule_sets)
       build_config_file(rule_sets)
       logger.debug "Dynamic configuration: #{[rule_sets]}"
+      rule_sets
     end
 
     def output_filter_set(rule_sets)
@@ -79,7 +80,7 @@ module PmdTester
     def build_config_file(rule_sets)
       if rule_sets.empty?
         logger.info NO_JAVA_RULES_CHANGED_MESSAGE
-        exit 0
+        return
       end
 
       doc = Nokogiri::XML(File.read(PATH_TO_ALL_JAVA_RULES))

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |s|
   s.name = "pmdtester".freeze
   s.version = "1.0.0.pre.SNAPSHOT"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 2.4.1".freeze) if s.respond_to? :required_rubygems_version=
+  s.required_rubygems_version = Gem::Requirement.new("= 2.7.6".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze]
-  s.date = "2018-09-08"
+  s.date = "2018-09-10"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@adangel.org".freeze, "djydewang@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/pmd/pmd-regression-tester".freeze
   s.licenses = ["BSD-2-Clause".freeze]
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
-  s.rubygems_version = "2.7.6".freeze
+  s.rubygems_version = "2.7.7".freeze
   s.summary = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
 
   if s.respond_to? :specification_version then


### PR DESCRIPTION
* Removes the exit statement in RuleSetBuilder Class
When pmdtester is used as a library, it will cause a lot of trouble for the caller if it contains an exit statement.
* Specify version of rdoc and rubygems