### PR TITLE
Reuse the built pmd if it exists already

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@
 *   [#40](https://github.com/pmd/pmd-regression-tester/issues/40): NoMethodError on beta3
 *   [#42](https://github.com/pmd/pmd-regression-tester/issues/42): Installing the snapshot version of pmdtester locally from github
 *   [#46](https://github.com/pmd/pmd-regression-tester/issues/46): Support multithreaded execution of PMD
+*   [#47](https://github.com/pmd/pmd-regression-tester/issues/47): Reuse the already built PMD binary for PR checks
 *   [#49](https://github.com/pmd/pmd-regression-tester/issues/49): Support comparing two error stacktraces
 *   [#50](https://github.com/pmd/pmd-regression-tester/issues/50): Differences due to different locale settings
 

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -47,6 +47,8 @@ module PmdTester
         end
         logger.info "Cloning #{project.name} completed"
       end
+
+      logger.info 'Cloning projects completed'
     end
 
     def get_pmd_binary_file
@@ -61,7 +63,8 @@ module PmdTester
         # and a binary zip already exists...
         if current_head_sha == current_branch_sha &&
            File.exist?("pmd-dist/target/pmd-bin-#{@pmd_version}.zip")
-          logger.warn "#{@pmd_branch_name}: Skipping packaging - zip already exists"
+          logger.warn "#{@pmd_branch_name}: Skipping packaging - zip for " \
+                      "#{@pmd_version} already exists"
         else
           build_pmd
         end
@@ -84,7 +87,7 @@ module PmdTester
       # determine the version again - it might be different in the other branch
       @pmd_version = determine_pmd_version
 
-      logger.info "#{@pmd_branch_name}: Building PMD..."
+      logger.info "#{@pmd_branch_name}: Building PMD #{@pmd_version}..."
       package_cmd = './mvnw clean package' \
                     ' -Dmaven.test.skip=true' \
                     ' -Dmaven.javadoc.skip=true' \

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -50,26 +50,52 @@ module PmdTester
     end
 
     def get_pmd_binary_file
-      logger.info 'Start packaging PMD'
+      logger.info "#{@pmd_branch_name}: Start packaging PMD"
       Dir.chdir(@local_git_repo) do
-        checkout_cmd = "git checkout #{@pmd_branch_name}"
-        Cmd.execute(checkout_cmd)
+        current_head_sha = Cmd.execute('git rev-parse HEAD')
+        current_branch_sha = Cmd.execute("git rev-parse #{@pmd_branch_name}")
+
+        @pmd_version = determine_pmd_version
+
+        # in case we are already on the correct branch
+        # and a binary zip already exists...
+        if current_head_sha == current_branch_sha &&
+           File.exist?("pmd-dist/target/pmd-bin-#{@pmd_version}.zip")
+          logger.warn "#{@pmd_branch_name}: Skipping packaging - zip already exists"
+        else
+          build_pmd
+        end
 
         @pmd_branch_details.branch_last_sha = get_last_commit_sha
         @pmd_branch_details.branch_last_message = get_last_commit_message
 
-        package_cmd = './mvnw clean package -Dpmd.skip=true -Dmaven.test.skip=true' \
-                      ' -Dmaven.checkstyle.skip=true -Dmaven.javadoc.skip=true'
-        Cmd.execute(package_cmd)
-
-        version_cmd = "./mvnw -q -Dexec.executable=\"echo\" -Dexec.args='${project.version}' " \
-                      '--non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec'
-        @pmd_version = Cmd.execute(version_cmd)
-
+        logger.info "#{@pmd_branch_name}: Extracting the zip"
         unzip_cmd = "unzip -qo pmd-dist/target/pmd-bin-#{@pmd_version}.zip -d #{@pwd}/target"
         Cmd.execute(unzip_cmd)
       end
-      logger.info 'Packaging PMD completed'
+      logger.info "#{@pmd_branch_name}: Packaging PMD completed"
+    end
+
+    def build_pmd
+      logger.info "#{@pmd_branch_name}: Checking out the branch"
+      checkout_cmd = "git checkout #{@pmd_branch_name}"
+      Cmd.execute(checkout_cmd)
+
+      # determine the version again - it might be different in the other branch
+      @pmd_version = determine_pmd_version
+
+      logger.info "#{@pmd_branch_name}: Building PMD..."
+      package_cmd = './mvnw clean package' \
+                    ' -Dmaven.test.skip=true' \
+                    ' -Dmaven.javadoc.skip=true' \
+                    ' -Dmaven.source.skip=true'
+      Cmd.execute(package_cmd)
+    end
+
+    def determine_pmd_version
+      version_cmd = "./mvnw -q -Dexec.executable=\"echo\" -Dexec.args='${project.version}' " \
+                    '--non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec'
+      Cmd.execute(version_cmd)
     end
 
     def get_last_commit_sha

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Unit test class for PmdReportBuilder
+class TestPmdReportBuilder < Test::Unit::TestCase
+  def test_build_skip
+    projects = []
+    argv = %w[-r target/repositories/pmd -b master -p pmd_releases/6.1.0
+              -c config/design.xml -l test/resources/project-test.xml]
+    options = PmdTester::Options.new(argv)
+
+    record_expectations('sha1abc', 'sha1abc', true)
+    record_expecations_after_build
+
+    PmdTester::PmdReportBuilder
+      .new(options.base_config, projects, options.local_git_repo, options.base_branch)
+      .build
+  end
+
+  def test_build_normal
+    projects = []
+    argv = %w[-r target/repositories/pmd -b master -p pmd_releases/6.1.0
+              -c config/design.xml -l test/resources/project-test.xml]
+    options = PmdTester::Options.new(argv)
+
+    # File does not exist yet this time...
+    record_expectations('sha1abc', 'sha1abc', false)
+    PmdTester::Cmd.stubs(:execute).with('git checkout master')
+                  .returns('checked out branch master').once
+    PmdTester::Cmd.stubs(:execute).with('./mvnw clean package -Dmaven.test.skip=true' \
+                  ' -Dmaven.javadoc.skip=true -Dmaven.source.skip=true').once
+    record_expecations_after_build
+
+    PmdTester::PmdReportBuilder
+      .new(options.base_config, projects, options.local_git_repo, options.base_branch)
+      .build
+  end
+
+  def record_expectations(sha1_head, sha1_base, zip_file_exists)
+    Dir.stubs(:getwd).returns('current-dir').once
+    Dir.stubs(:chdir).with('target/repositories/pmd').yields.once
+    PmdTester::Cmd.stubs(:execute).with('git rev-parse HEAD').returns(sha1_head).once
+    PmdTester::Cmd.stubs(:execute).with('git rev-parse master').returns(sha1_base).once
+    PmdTester::Cmd.stubs(:execute).with('./mvnw -q -Dexec.executable="echo" ' \
+                  "-Dexec.args='${project.version}' " \
+                  '--non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec')
+                  .returns('6.10.0-SNAPSHOT').at_least(1).at_most(2)
+    # File does not exist yet this time...
+    File.stubs(:exist?).with('pmd-dist/target/pmd-bin-6.10.0-SNAPSHOT.zip')
+        .returns(zip_file_exists).once
+  end
+
+  def record_expecations_after_build
+    PmdTester::Cmd.stubs(:execute).with('git rev-parse HEAD').returns('sha1abc').once
+    PmdTester::Cmd.stubs(:execute).with('git log -1 --pretty=%B').returns('the commit message').once
+    PmdTester::Cmd.stubs(:execute).with('unzip -qo pmd-dist/target/pmd-bin-6.10.0-SNAPSHOT.zip' \
+                  ' -d current-dir/target').once
+    PmdTester::PmdBranchDetail.any_instance.stubs(:save).once
+    FileUtils.stubs(:cp).with('config/design.xml', 'target/reports/master/config.xml').once
+  end
+end


### PR DESCRIPTION
I didn't create a configuration flag for now - so this is the standard behavior: If you execute pmdtester on a pmd repository, which is in the correct branch and happens to have a pmd-dist/target/pmd-bin-VERSION.zip file existing already, then PMD is not built - the zip file is used instead.
