### PR TITLE
Report contains errors having nil filename

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,8 @@
 
 ## Fixed Issues
 
+*   [#67](https://github.com/pmd/pmd-regression-tester/pull/67): Report contains errors having nil filename
+
 ## External Contributions
 
 # 1.0.1 / 2020-07-08

--- a/lib/pmdtester/builders/diff_report_builder.rb
+++ b/lib/pmdtester/builders/diff_report_builder.rb
@@ -91,7 +91,7 @@ module PmdTester
     def build_filename_h3(doc, filename)
       if filename.nil?
         doc.h3 do
-          doc.text "(unknown file)"
+          doc.text '(unknown file)'
         end
       else
         doc.h3 do

--- a/lib/pmdtester/builders/diff_report_builder.rb
+++ b/lib/pmdtester/builders/diff_report_builder.rb
@@ -89,9 +89,15 @@ module PmdTester
     end
 
     def build_filename_h3(doc, filename)
-      doc.h3 do
-        doc.a(href: @project.get_webview_url(filename)) do
-          doc.text @project.get_path_inside_project(filename)
+      if filename.nil?
+        doc.h3 do
+          doc.text "(unknown file)"
+        end
+      else
+        doc.h3 do
+          doc.a(href: @project.get_webview_url(filename)) do
+            doc.text @project.get_path_inside_project(filename)
+          end
         end
       end
     end

--- a/lib/pmdtester/parsers/pmd_report_document.rb
+++ b/lib/pmdtester/parsers/pmd_report_document.rb
@@ -29,13 +29,15 @@ module PmdTester
 
       case name
       when 'file'
+        remove_work_dir!(attrs['name'])
         @current_violations = []
-        @current_filename = remove_work_dir!(attrs['name'])
+        @current_filename = attrs['name']
       when 'violation'
         @current_violation = PmdViolation.new(attrs, @branch_name)
       when 'error'
-        @current_filename = remove_work_dir!(attrs['filename'])
+        remove_work_dir!(attrs['filename'])
         remove_work_dir!(attrs['msg'])
+        @current_filename = attrs['filename']
         @current_error = PmdError.new(attrs, @branch_name)
       when 'configerror'
         @current_configerror = PmdConfigError.new(attrs, @branch_name)

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/pmd/pmd-regression-tester/issues", "homepage_uri" => "https://pmd.github.io", "source_code_uri" => "https://github.com/pmd/pmd-regression-tester" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze]
-  s.date = "2020-10-08"
+  s.date = "2020-10-09"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@pmd-code.org".freeze, "djydewang@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]

--- a/test/resources/pmd_report_document/error_filename_without_path.xml
+++ b/test/resources/pmd_report_document/error_filename_without_path.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pmd xmlns="http://pmd.sourceforge.net/report/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd"
+    version="6.3.0-SNAPSHOT" timestamp="2018-04-16T22:41:45.065">
+<error filename="InputXpathQueryGeneratorTabWidth.java" msg="NullPointerException: null">
+<![CDATA[java.lang.NullPointerException
+        at net.sourceforge.pmd.lang.java.rule.multithreading.DoubleCheckedLockingRule.visit(DoubleCheckedLockingRule.java:94)
+        at net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration.acceptVisitor(ASTMethodDeclaration.java:49)
+        at net.sourceforge.pmd.lang.java.ast.AbstractJavaNode.acceptVisitor(AbstractJavaNode.java:41)
+        at net.sourceforge.pmd.lang.java.ast.JavaParserVisitor.visitNode(JavaParserVisitor.java:22)
+        at net.sourceforge.pmd.lang.java.ast.JavaVisitor.visitJavaNode(JavaVisitor.java:6)
+        at net.sourceforge.pmd.lang.java.ast.JavaVisitor.visit(JavaVisitor.java:25)
+        at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody.acceptVisitor(ASTClassOrInterfaceBody.java:26)
+        at net.sourceforge.pmd.lang.java.ast.AbstractJavaNode.acceptVisitor(AbstractJavaNode.java:41)
+        at net.sourceforge.pmd.lang.java.ast.JavaParserVisitor.visitNode(JavaParserVisitor.java:22)
+        at net.sourceforge.pmd.lang.java.ast.JavaVisitor.visitJavaNode(JavaVisitor.java:6)
+        at net.sourceforge.pmd.lang.java.ast.JavaVisitor.visit(JavaVisitor.java:11)
+        at net.sourceforge.pmd.lang.java.rule.multithreading.DoubleCheckedLockingRule.visit(DoubleCheckedLockingRule.java:68)
+        at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration.acceptVisitor(ASTClassOrInterfaceDeclaration.java:39)
+        at net.sourceforge.pmd.lang.java.ast.AbstractJavaNode.acceptVisitor(AbstractJavaNode.java:41)
+        at net.sourceforge.pmd.lang.java.ast.JavaParserVisitor.visitNode(JavaParserVisitor.java:22)
+        at net.sourceforge.pmd.lang.java.ast.JavaVisitor.visitJavaNode(JavaVisitor.java:6)
+        at net.sourceforge.pmd.lang.java.ast.JavaVisitor.visit(JavaVisitor.java:7)
+        at net.sourceforge.pmd.lang.java.rule.multithreading.DoubleCheckedLockingRule.visit(DoubleCheckedLockingRule.java:78)
+        at net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit.acceptVisitor(ASTCompilationUnit.java:44)
+        at net.sourceforge.pmd.lang.java.ast.AbstractJavaNode.acceptVisitor(AbstractJavaNode.java:41)
+        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.apply(AbstractJavaRule.java:38)
+        at net.sourceforge.pmd.lang.rule.AbstractDelegateRule.apply(AbstractDelegateRule.java:243)
+        at net.sourceforge.pmd.lang.rule.internal.RuleApplicator.applyOnIndex(RuleApplicator.java:61)
+        at net.sourceforge.pmd.lang.rule.internal.RuleApplicator.apply(RuleApplicator.java:47)
+        at net.sourceforge.pmd.RuleSets.apply(RuleSets.java:145)
+        at net.sourceforge.pmd.SourceCodeProcessor.processSource(SourceCodeProcessor.java:161)
+        at net.sourceforge.pmd.SourceCodeProcessor.processSourceCodeWithoutCache(SourceCodeProcessor.java:104)
+        at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:86)
+        at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:51)
+        at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:78)
+        at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:24)
+        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
+        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
+        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
+        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+        at java.base/java.lang.Thread.run(Thread.java:834)
+]]>
+</error>
+</pmd>

--- a/test/test_pmd_report_document.rb
+++ b/test/test_pmd_report_document.rb
@@ -26,4 +26,14 @@ class TestPmdReportDocument < Test::Unit::TestCase
     assert_equal(1, doc.violations.violations_size)
     # TODO: check size of filtered errors
   end
+
+  def test_error_filename_without_path
+    doc = PmdReportDocument.new('base', '/tmp/workingDirectory')
+    parser = Nokogiri::XML::SAX::Parser.new(doc)
+    parser.parse(File.open('test/resources/pmd_report_document/error_filename_without_path.xml'))
+    assert_equal(1, doc.errors.errors_size)
+    filenames = doc.errors.errors.keys
+    assert_equal(1, filenames.length)
+    assert_equal('InputXpathQueryGeneratorTabWidth.java', filenames[0])
+  end
 end


### PR DESCRIPTION
Extract this fix from #65 (note: this is cherry-picked so not the same commit). I didn't pinpoint what specific errors cause that, but we may be able to see it as we experiment with the regression tester