### PR TITLE
Don't generate a dynamic ruleset if not needed

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@
 ## Fixed Issues
 
 *   [#67](https://github.com/pmd/pmd-regression-tester/pull/67): Report contains errors having nil filename
+*   [#68](https://github.com/pmd/pmd-regression-tester/pull/68): Don't generate a dynamic ruleset if not needed
 
 ## External Contributions
 

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ hoe = Hoe.spec 'pmdtester' do
   developer 'Andreas Dangel', 'andreas.dangel@pmd-code.org'
   developer 'Binguo Bao', 'djydewang@gmail.com'
 
-  self.clean_globs = %w[target/reports/**/* target/test/**/* Gemfile.lock]
+  self.clean_globs = %w[target/reports/**/* target/test/**/* target/dynamic-config.xml Gemfile.lock]
   self.extra_deps += [['nokogiri', '~> 1.8'], ['slop', '~> 4.6'], ['differ', '~> 0.1'],
                       ['rufus-scheduler', '~> 3.5']]
   self.extra_dev_deps += [

--- a/lib/pmdtester/builders/rule_set_builder.rb
+++ b/lib/pmdtester/builders/rule_set_builder.rb
@@ -28,7 +28,6 @@ module PmdTester
       rule_sets = get_rule_sets(filenames)
       output_filter_set(rule_sets)
       build_config_file(rule_sets)
-      logger.debug "Dynamic configuration: #{[rule_sets]}"
       rule_sets
     end
 
@@ -82,6 +81,15 @@ module PmdTester
         logger.info NO_JAVA_RULES_CHANGED_MESSAGE
         return
       end
+
+      if rule_sets == ALL_RULE_SETS
+        logger.debug 'All rules are used. Not generating a dynamic ruleset.'
+        logger.debug "Using the configured/default ruleset base_config=#{@options.base_config} "\
+                     "patch_config=#{@options.patch_config}"
+        return
+      end
+
+      logger.debug "Generating dynamic configuration for: #{[rule_sets]}"
 
       doc = Nokogiri::XML(File.read(PATH_TO_ALL_JAVA_RULES))
       doc.search('rule').each do |rule|


### PR DESCRIPTION
In case all rules should be executed anyway, just use the configured config.

With that change, a report for pmd/pmd#2800 is generated successfully. However, not very useful, since we only see, that all MissingOverride violations are new....
