### PR TITLE
Add link to PR on github in HTML report

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -25,6 +25,7 @@ lib/pmdtester/builders/html_report_builder.rb
 lib/pmdtester/builders/pmd_report_builder.rb
 lib/pmdtester/builders/rule_set_builder.rb
 lib/pmdtester/builders/simple_progress_logger.rb
+lib/pmdtester/builders/summary_report/branch_name_row.rb
 lib/pmdtester/builders/summary_report_builder.rb
 lib/pmdtester/cmd.rb
 lib/pmdtester/parsers/options.rb

--- a/lib/pmdtester.rb
+++ b/lib/pmdtester.rb
@@ -22,6 +22,7 @@ require_relative 'pmdtester/builders/diff_report/errors'
 require_relative 'pmdtester/builders/diff_report_builder'
 require_relative 'pmdtester/builders/pmd_report_builder'
 require_relative 'pmdtester/builders/rule_set_builder'
+require_relative 'pmdtester/builders/summary_report/branch_name_row'
 require_relative 'pmdtester/builders/summary_report_builder'
 
 require_relative 'pmdtester/parsers/options'

--- a/lib/pmdtester/builders/diff_report_builder.rb
+++ b/lib/pmdtester/builders/diff_report_builder.rb
@@ -56,39 +56,80 @@ module PmdTester
 
     def build_summary_table_body(doc)
       doc.tbody do
-        build_summary_row(doc, 'number of errors', 'Errors', @report_diff.base_errors_size,
-                          @report_diff.patch_errors_size, @report_diff.removed_errors_size,
-                          @report_diff.new_errors_size)
-        build_summary_row(doc, 'number of violations', 'Violations', @report_diff.base_violations_size,
-                          @report_diff.patch_violations_size, @report_diff.removed_violations_size,
-                          @report_diff.new_violations_size)
-        build_summary_row(doc, 'number of config errors', 'configerrors', @report_diff.base_configerrors_size,
-                          @report_diff.patch_configerrors_size,
-                          @report_diff.removed_configerrors_size,
-                          @report_diff.new_configerrors_size)
-        build_summary_row(doc, 'execution time', '', @report_diff.base_execution_time,
-                          @report_diff.patch_execution_time, @report_diff.diff_execution_time)
-        build_summary_row(doc, 'timestamp', '', @report_diff.base_timestamp,
-                          @report_diff.patch_timestamp, '')
+        build_error_summary_row(doc)
+        build_violations_summary_row(doc)
+        build_configerrors_summary_row(doc)
+        build_execution_time_summary_row(doc)
+        build_timestamp_summary_row(doc)
       end
     end
 
-    def build_summary_row(doc, item, target, base, patch, *diff)
+    def build_error_summary_row(doc)
+      build_summary_row(doc, {
+                          title: 'number of errors',
+                          target: 'Errors',
+                          base: @report_diff.base_errors_size,
+                          patch: @report_diff.patch_errors_size,
+                          removed: @report_diff.removed_errors_size,
+                          added: @report_diff.new_errors_size
+                        })
+    end
+
+    def build_violations_summary_row(doc)
+      build_summary_row(doc, {
+                          title: 'number of violations',
+                          target: 'Violations',
+                          base: @report_diff.base_violations_size,
+                          patch: @report_diff.patch_violations_size,
+                          removed: @report_diff.removed_violations_size,
+                          added: @report_diff.new_violations_size
+                        })
+    end
+
+    def build_configerrors_summary_row(doc)
+      build_summary_row(doc, {
+                          title: 'number of config errors',
+                          target: 'configerrors',
+                          base: @report_diff.base_configerrors_size,
+                          patch: @report_diff.patch_configerrors_size,
+                          removed: @report_diff.removed_configerrors_size,
+                          added: @report_diff.new_configerrors_size
+                        })
+    end
+
+    def build_execution_time_summary_row(doc)
+      build_summary_row(doc, {
+                          title: 'execution time',
+                          base: @report_diff.base_execution_time,
+                          patch: @report_diff.patch_execution_time,
+                          diff_execution_time: @report_diff.diff_execution_time
+                        })
+    end
+
+    def build_timestamp_summary_row(doc)
+      build_summary_row(doc, {
+                          title: 'timestamp',
+                          base: @report_diff.base_timestamp,
+                          patch: @report_diff.patch_timestamp
+                        })
+    end
+
+    def build_summary_row(doc, row_data)
       doc.tr do
         doc.td(class: 'c') do
-          if target != ''
-            doc.a(href: "##{target}") { doc.text item }
+          if row_data.key?(:target)
+            doc.a(href: "##{row_data[:target]}") { doc.text row_data[:title] }
           else
-            doc.text item
+            doc.text row_data[:title]
           end
         end
-        doc.td(class: 'b') { doc.text base }
-        doc.td(class: 'a') { doc.text patch }
+        doc.td(class: 'b') { doc.text row_data[:base] }
+        doc.td(class: 'a') { doc.text row_data[:patch] }
         doc.td(class: 'c') do
-          if diff.size == 1
-            doc.text diff[0]
-          else
-            build_table_content_for(doc, diff[0], diff[1])
+          if row_data.key?(:removed) && row_data.key?(:added)
+            build_table_content_for(doc, row_data[:removed], row_data[:added])
+          elsif row_data.key?(:diff_execution_time)
+            doc.text row_data[:diff_execution_time]
           end
         end
       end

--- a/lib/pmdtester/builders/diff_report_builder.rb
+++ b/lib/pmdtester/builders/diff_report_builder.rb
@@ -56,26 +56,32 @@ module PmdTester
 
     def build_summary_table_body(doc)
       doc.tbody do
-        build_summary_row(doc, 'number of errors', @report_diff.base_errors_size,
+        build_summary_row(doc, 'number of errors', 'Errors', @report_diff.base_errors_size,
                           @report_diff.patch_errors_size, @report_diff.removed_errors_size,
                           @report_diff.new_errors_size)
-        build_summary_row(doc, 'number of violations', @report_diff.base_violations_size,
+        build_summary_row(doc, 'number of violations', 'Violations', @report_diff.base_violations_size,
                           @report_diff.patch_violations_size, @report_diff.removed_violations_size,
                           @report_diff.new_violations_size)
-        build_summary_row(doc, 'number of config errors', @report_diff.base_configerrors_size,
+        build_summary_row(doc, 'number of config errors', 'configerrors', @report_diff.base_configerrors_size,
                           @report_diff.patch_configerrors_size,
                           @report_diff.removed_configerrors_size,
                           @report_diff.new_configerrors_size)
-        build_summary_row(doc, 'execution time', @report_diff.base_execution_time,
+        build_summary_row(doc, 'execution time', '', @report_diff.base_execution_time,
                           @report_diff.patch_execution_time, @report_diff.diff_execution_time)
-        build_summary_row(doc, 'timestamp', @report_diff.base_timestamp,
+        build_summary_row(doc, 'timestamp', '', @report_diff.base_timestamp,
                           @report_diff.patch_timestamp, '')
       end
     end
 
-    def build_summary_row(doc, item, base, patch, *diff)
+    def build_summary_row(doc, item, target, base, patch, *diff)
       doc.tr do
-        doc.td(class: 'c') { doc.text item }
+        doc.td(class: 'c') do
+          if target != ''
+            doc.a(href: "##{target}") { doc.text item }
+          else
+            doc.text item
+          end
+        end
         doc.td(class: 'b') { doc.text base }
         doc.td(class: 'a') { doc.text patch }
         doc.td(class: 'c') do

--- a/lib/pmdtester/builders/summary_report/branch_name_row.rb
+++ b/lib/pmdtester/builders/summary_report/branch_name_row.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Contains methods to write out html for the branch name summary row.
+# This mixin is used by SummaryReportBuilder.
+module SummaryReportBuilderBranchNameRow
+  def build_branch_name_table_row(doc)
+    doc.tr do
+      doc.td(class: 'c') { doc.text 'branch name' }
+      doc.td(class: 'a') do
+        doc.a(href: "https://github.com/pmd/pmd/tree/#{@base_details.branch_name}") do
+          doc.text @base_details.branch_name
+        end
+      end
+      doc.td(class: 'b') do
+        doc.a(href: "https://github.com/pmd/pmd/tree/#{@patch_details.branch_last_sha}") do
+          doc.text @patch_details.branch_name
+        end
+        build_pull_request_info(doc, @patch_details.pull_request)
+        build_compare_github_link(doc, @base_details.branch_name, @patch_details.branch_last_sha)
+      end
+    end
+  end
+
+  def build_pull_request_info(doc, pull_request)
+    return if pull_request == 'false'
+
+    doc.br
+    doc.text "\n"
+    doc.a(href: "https://github.com/pmd/pmd/pulls/#{pull_request}") do
+      doc.text "PR ##{pull_request}"
+    end
+  end
+
+  def build_compare_github_link(doc, from, to)
+    doc.br
+    doc.text "\n"
+    doc.a(href: "https://github.com/pmd/pmd/compare/#{from}...#{to}") do
+      doc.text 'Compare changes'
+    end
+  end
+end

--- a/lib/pmdtester/builders/summary_report_builder.rb
+++ b/lib/pmdtester/builders/summary_report_builder.rb
@@ -4,6 +4,8 @@ module PmdTester
   # Building summary report to show the details about projects and pmd branchs
   class SummaryReportBuilder < HtmlReportBuilder
     include PmdTester
+    include SummaryReportBuilderBranchNameRow
+
     REPORT_DIR = 'target/reports/diff'
     BASE_CONFIG_PATH = 'target/reports/diff/base_config.xml'
     PATCH_CONFIG_PATH = 'target/reports/diff/patch_config.xml'
@@ -62,8 +64,7 @@ module PmdTester
 
     def build_branch_table_body(doc)
       doc.tbody do
-        build_branch_table_row(doc, 'branch name', @base_details.branch_name,
-                               @patch_details.branch_name)
+        build_branch_name_table_row(doc)
         build_branch_table_row(doc, 'branch last commit sha', @base_details.branch_last_sha,
                                @patch_details.branch_last_sha)
         build_branch_table_row(doc, 'branch last commit message', @base_details.branch_last_message,

--- a/lib/pmdtester/pmd_branch_detail.rb
+++ b/lib/pmdtester/pmd_branch_detail.rb
@@ -14,6 +14,7 @@ module PmdTester
     attr_accessor :execution_time
     attr_reader :jdk_version
     attr_reader :language
+    attr_reader :pull_request
 
     def self.branch_filename(branch_name)
       branch_name&.tr('/', '_')
@@ -29,6 +30,7 @@ module PmdTester
       # the result of command 'java -version' is going to stderr
       @jdk_version = Cmd.stderr_of('java -version')
       @language = ENV['LANG']
+      @pull_request = ENV['TRAVIS_PULL_REQUEST']
     end
 
     def load
@@ -40,6 +42,7 @@ module PmdTester
         @execution_time = hash['execution_time']
         @jdk_version = hash['jdk_version']
         @language = hash['language']
+        @pull_request = hash['pull_request']
       else
         @jdk_version = ''
         @language = ''
@@ -54,7 +57,8 @@ module PmdTester
                branch_name: @branch_name,
                execution_time: @execution_time,
                jdk_version: @jdk_version,
-               language: @language }
+               language: @language,
+               pull_request: @pull_request }
       file = File.new(branch_details_path, 'w')
       file.puts JSON.generate(hash)
       file.close

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/pmd/pmd-regression-tester/issues", "homepage_uri" => "https://pmd.github.io", "source_code_uri" => "https://github.com/pmd/pmd-regression-tester" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze]
-  s.date = "2020-10-09"
+  s.date = "2020-10-16"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@pmd-code.org".freeze, "djydewang@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]

--- a/test/resources/html_report_builder/expected_diff_report_index.html
+++ b/test/resources/html_report_builder/expected_diff_report_index.html
@@ -16,7 +16,7 @@
 </tr></thead>
 <tbody>
 <tr>
-<td class="c">number of errors</td>
+<td class="c"><a href="#Errors">number of errors</a></td>
 <td class="b">1</td>
 <td class="a">1</td>
 <td class="c">
@@ -24,7 +24,7 @@
 </td>
 </tr>
 <tr>
-<td class="c">number of violations</td>
+<td class="c"><a href="#Violations">number of violations</a></td>
 <td class="b">5</td>
 <td class="a">8</td>
 <td class="c">
@@ -32,7 +32,7 @@
 </td>
 </tr>
 <tr>
-<td class="c">number of config errors</td>
+<td class="c"><a href="#configerrors">number of config errors</a></td>
 <td class="b">1</td>
 <td class="a">2</td>
 <td class="c">

--- a/test/resources/html_report_builder/expected_empty_diff_report.html
+++ b/test/resources/html_report_builder/expected_empty_diff_report.html
@@ -16,7 +16,7 @@
 </tr></thead>
 <tbody>
 <tr>
-<td class="c">number of errors</td>
+<td class="c"><a href="#Errors">number of errors</a></td>
 <td class="b">0</td>
 <td class="a">0</td>
 <td class="c">
@@ -24,7 +24,7 @@
 </td>
 </tr>
 <tr>
-<td class="c">number of violations</td>
+<td class="c"><a href="#Violations">number of violations</a></td>
 <td class="b">0</td>
 <td class="a">0</td>
 <td class="c">
@@ -32,7 +32,7 @@
 </td>
 </tr>
 <tr>
-<td class="c">number of config errors</td>
+<td class="c"><a href="#configerrors">number of config errors</a></td>
 <td class="b">0</td>
 <td class="a">0</td>
 <td class="c">

--- a/test/resources/summary_report_builder/branch_info.json
+++ b/test/resources/summary_report_builder/branch_info.json
@@ -1,2 +1,9 @@
-{"branch_last_sha":"test sha","branch_last_message":"test message","branch_name":"test_branch","execution_time":121,
-"jdk_version":"test version", "language":"test language"}
+{
+    "branch_last_sha":"test sha",
+    "branch_last_message":"test message",
+    "branch_name":"test_branch",
+    "execution_time":121,
+    "jdk_version":"test version",
+    "language":"test language",
+    "pull_request":42
+}

--- a/test/resources/summary_report_builder/expected_index.html
+++ b/test/resources/summary_report_builder/expected_index.html
@@ -15,8 +15,12 @@
 <tbody>
 <tr>
 <td class="c">branch name</td>
-<td class="a">test_branch</td>
-<td class="b">test_branch</td>
+<td class="a"><a href="https://github.com/pmd/pmd/tree/test_branch">test_branch</a></td>
+<td class="b">
+<a href="https://github.com/pmd/pmd/tree/test%20sha">test_branch</a><br>
+<a href="https://github.com/pmd/pmd/pulls/42">PR #42</a><br>
+<a href="https://github.com/pmd/pmd/compare/test_branch...test%20sha">Compare changes</a>
+</td>
 </tr>
 <tr>
 <td class="c">branch last commit sha</td>

--- a/test/test_pmd_branch_detail.rb
+++ b/test/test_pmd_branch_detail.rb
@@ -4,7 +4,16 @@ require 'test_helper'
 
 # Unit test class for PmdTester::PmdBranchDetail
 class TestPmdBranchDetail < Test::Unit::TestCase
+  def setup
+    @old_pr = ENV['TRAVIS_PULL_REQUEST']
+  end
+
+  def cleanup
+    ENV['TRAVIS_PULL_REQUEST'] = @old_pr
+  end
+
   def test_save_and_load
+    ENV['TRAVIS_PULL_REQUEST'] = '1234'
     details = PmdTester::PmdBranchDetail.new('test_branch')
     details.branch_last_message = 'test message'
     details.branch_last_sha = 'test sha'
@@ -23,6 +32,7 @@ class TestPmdBranchDetail < Test::Unit::TestCase
     assert_not_empty(details.jdk_version)
     assert_equal(ENV['LANG'], details.language)
     assert_not_empty(details.language)
+    assert_equal('1234', details.pull_request)
   end
 
   def test_get_path


### PR DESCRIPTION
This PR adds these improvements:
* In the summary section, a link back to the Pull-Request is added (given, that we run on travis and TRAVIS_PULL_REQUEST is set)
* Additionally a link to the code on github is added for the two branches and additionally the github compare view link for the patch
* On the detailed report page, you can now jump directly to the violations / errors / configerrors
