### PR TITLE
Speedup XML parsing

### DIFF
--- a/lib/pmdtester/parsers/pmd_report_document.rb
+++ b/lib/pmdtester/parsers/pmd_report_document.rb
@@ -58,8 +58,10 @@ module PmdTester
         @violations.add_violations_by_filename(@current_filename, @current_violations)
         @current_filename = nil
       when 'violation'
-        @current_violation.text.strip!
-        @current_violations.push(@current_violation) if match_filter_set?(@current_violation)
+        if match_filter_set?(@current_violation)
+          @current_violation.text.strip!
+          @current_violations.push(@current_violation)
+        end
         @current_violation = nil
       when 'error'
         @errors.add_error_by_filename(@current_filename, @current_error)
@@ -79,15 +81,12 @@ module PmdTester
     def match_filter_set?(violation)
       return true if @filter_set.nil?
 
-      @filter_set.each do |filter_rule_ref|
-        ruleset_attr = violation.attrs['ruleset'].delete(' ').downcase + '.xml'
-        rule = violation.rule_name
-        rule_ref = "#{ruleset_attr}/#{rule}"
-        return true if filter_rule_ref.eql?(ruleset_attr)
-        return true if filter_rule_ref.eql?(rule_ref)
-      end
+      ruleset_attr = violation.attrs['ruleset'].delete(' ').downcase + '.xml'
+      return true if @filter_set.include?(ruleset_attr)
 
-      false
+      rule_ref = "#{ruleset_attr}/#{violation.rule_name}"
+
+      @filter_set.include?(rule_ref)
     end
   end
 end


### PR DESCRIPTION
The report parser is spending a significant amount of time checking for inclusion in the rule filter, which matters when there are many violations (eg the spring report for master has around 330K, and the xml file is 136MB). This just avoids iterating on the set, also the rule ref was previously computed on each iteration even though it's independent of the iteration variable.


Here's a [benchmark](https://github.com/oowekyala/pmd-regression-tester/commit/b1c30222c98cf4fe6316a11efea9610eaeba331c):
Master:
<pre>
I, [2020-11-10T15:39:42.782890 #12087]  INFO -- : Preparing report for checkstyle
                                                           user     system      total        real
Parse target/reports/master/checkstyle/pmd_report.xml  5.281445   0.028173   5.309618 (  5.309581)
Parse target/reports/HEAD/checkstyle/pmd_report.xml    0.109253   0.000024   0.109277 (  0.133201)
Calc differences                                       1.550513   0.000000   1.550513 (  1.550567)
I, [2020-11-10T15:39:53.034839 #12087]  INFO -- : Built difference report of checkstyle successfully!
I, [2020-11-10T15:39:53.034899 #12087]  INFO -- : Preparing report for spring-framework
                                                                 user     system      total        real
Parse target/reports/master/spring-framework/pmd_report.xml105.977608   0.059953 106.037561 (<b>106.046885</b>)
Parse target/reports/HEAD/spring-framework/pmd_report.xml    0.782001   0.007995   0.789996 (  0.790528)
Calc differences                                             1.703429   0.007999   1.711428 (  1.711553)
</pre>

Now:
<pre>


I, [2020-11-10T15:36:01.435522 #10998]  INFO -- : Preparing report for checkstyle
                                                           user     system      total        real
Parse target/reports/master/checkstyle/pmd_report.xml  1.424196   0.008773   1.432969 (  1.432834)
Parse target/reports/HEAD/checkstyle/pmd_report.xml    0.091308   0.000000   0.091308 (  0.091887)
Calc differences                                       1.394529   0.000089   1.394618 (  1.394638)
I, [2020-11-10T15:36:07.607545 #10998]  INFO -- : Built difference report of checkstyle successfully!
I, [2020-11-10T15:36:07.607607 #10998]  INFO -- : Preparing report for spring-framework
                                                                 user     system      total        real
Parse target/reports/master/spring-framework/pmd_report.xml 83.292899   0.072141  83.365040 (<b>83.369749</b>)
Parse target/reports/HEAD/spring-framework/pmd_report.xml    0.452257   0.000001   0.452258 (  0.476918)
Calc differences                                             1.450993   0.000006   1.450999 (  1.451078)
I, [2020-11-10T15:37:48.998717 #10998]  INFO -- : Built difference report of spring-framework successfully!
</pre>
