### PR TITLE
Cache and reuse pmd builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ hoe = Hoe.spec 'pmdtester' do
 
   self.clean_globs = %w[target/reports/**/* target/test/**/* target/dynamic-config.xml Gemfile.lock]
   self.extra_deps += [['nokogiri', '~> 1.8'], ['slop', '~> 4.6'], ['differ', '~> 0.1'],
-                      ['rufus-scheduler', '~> 3.5']]
+                      ['rufus-scheduler', '~> 3.5'], ['logger-colors', '~> 1.0']]
   self.extra_dev_deps += [
     ['hoe-bundler',   '~> 1.5'],
     ['hoe-git',       '~> 1.6'],

--- a/lib/pmdtester.rb
+++ b/lib/pmdtester.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger'
+require 'logger/colors'
 
 require_relative 'pmdtester/cmd'
 require_relative 'pmdtester/pmd_branch_detail'

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -41,8 +41,6 @@ module PmdTester
           build_pmd(into_dir: distro_path)
         end
 
-        raise "Should have built #{distro_path}" unless File.directory?(distro_path)
-
         # we're still on the build branch
         @pmd_branch_details.branch_last_sha = build_branch_sha
         @pmd_branch_details.branch_last_message = get_last_commit_message

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -24,10 +24,13 @@ module PmdTester
     def get_pmd_binary_file
       logger.info "#{@pmd_branch_name}: Start packaging PMD"
       Dir.chdir(@local_git_repo) do
-        current_head_sha = Cmd.execute('git rev-parse HEAD')
-        current_branch_sha = Cmd.execute("git rev-parse #{@pmd_branch_name}")
+        current_head_sha = get_last_commit_sha
+        current_branch_sha = Cmd.execute("git rev-parse #{@pmd_branch_name}^{commit}")
 
         @pmd_version = determine_pmd_version
+
+        logger.debug "pmd_version in HEAD: #{@pmd_version}, " \
+                     "head_sha=#{current_head_sha}, branch_sha=#{current_branch_sha}"
 
         # in case we are already on the correct branch
         # and a binary zip already exists...
@@ -73,7 +76,7 @@ module PmdTester
     end
 
     def get_last_commit_sha
-      get_last_commit_sha_cmd = 'git rev-parse HEAD'
+      get_last_commit_sha_cmd = 'git rev-parse HEAD^{commit}'
       Cmd.execute(get_last_commit_sha_cmd)
     end
 

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -169,8 +169,11 @@ module PmdTester
     end
 
     # path to the unzipped distribution
+    # e.g. <cwd>/pmd-bin-<version>-<branch>-<sha>
     def saved_distro_path(build_sha)
-      "#{work_dir}/pmd-bin-#{build_sha}"
+      "#{work_dir}/pmd-bin-#{@pmd_version}" \
+      "-#{PmdBranchDetail.branch_filename(@pmd_branch_name)}" \
+      "-#{build_sha}"
     end
 
     def wd_has_dirty_git_changes

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -170,7 +170,8 @@ module PmdTester
 
       # working dir is dirty....
       # we don't allow this because we need the SHA to address the zip file
-      logger.error 'Won\'t build without a clean working tree, commit your changes'
+      logger.error "#{@pmd_branch_name}: Won\'t build without a clean working tree, " \
+                   'commit your changes'
     end
 
     def work_dir

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -22,21 +22,20 @@ module PmdTester
     end
 
     def get_pmd_binary_file
-
       logger.info "#{@pmd_branch_name}: Start packaging PMD"
       Dir.chdir(@local_git_repo) do
-
         build_branch_sha = Cmd.execute("git rev-parse #{@pmd_branch_name}^{commit}")
 
         checkout_build_branch # needs a clean working tree, otherwise fails
 
         raise "Wrong branch #{get_last_commit_sha}" unless build_branch_sha == get_last_commit_sha
 
-        logger.debug "pmd_version in branch #{@pmd_branch_name}: #{@pmd_version}, " \
-                     "branch_sha=#{build_branch_sha}"
+        logger.debug "#{@pmd_branch_name}: PMD Version is #{@pmd_version} " \
+                     "(sha=#{build_branch_sha})"
         distro_path = saved_distro_path(build_branch_sha)
         if File.directory?(distro_path)
-          logger.info "#{@pmd_branch_name}: Skipping packaging - saved version exists"
+          logger.info "#{@pmd_branch_name}: Skipping packaging - saved version exists " \
+                      " in #{distro_path}"
         else
           build_pmd(into_dir: distro_path)
         end
@@ -44,13 +43,12 @@ module PmdTester
         # we're still on the build branch
         @pmd_branch_details.branch_last_sha = build_branch_sha
         @pmd_branch_details.branch_last_message = get_last_commit_message
-
       end
       logger.info "#{@pmd_branch_name}: Packaging PMD completed"
     end
 
-    def build_pmd(into_dir:) # on current branch
-
+    # builds pmd on currently checked out branch
+    def build_pmd(into_dir:)
       logger.info "#{@pmd_branch_name}: Building PMD #{@pmd_version}..."
       package_cmd = './mvnw clean package' \
                     ' -Dmaven.test.skip=true' \
@@ -60,7 +58,8 @@ module PmdTester
       Cmd.execute(package_cmd)
 
       logger.info "#{@pmd_branch_name}: Extracting the zip"
-      Cmd.execute("unzip -qo pmd-dist/target/pmd-bin-#{@pmd_version}.zip -d pmd-dist/target/exploded")
+      Cmd.execute("unzip -qo pmd-dist/target/pmd-bin-#{@pmd_version}.zip" \
+                  ' -d pmd-dist/target/exploded')
       Cmd.execute("mv pmd-dist/target/exploded/pmd-bin-#{@pmd_version} #{into_dir}")
     end
 
@@ -158,10 +157,11 @@ module PmdTester
       # determine the version
       @pmd_version = determine_pmd_version
 
-      if wd_has_dirty_git_changes
-        # this is because we need the SHA to address the zip file
-        logger.error 'Won\'t build without a clean working tree, commit your changes'
-      end
+      return unless wd_has_dirty_git_changes
+
+      # working dir is dirty....
+      # we don't allow this because we need the SHA to address the zip file
+      logger.error 'Won\'t build without a clean working tree, commit your changes'
     end
 
     def work_dir
@@ -174,7 +174,7 @@ module PmdTester
     end
 
     def wd_has_dirty_git_changes
-      !Cmd.execute("git status --porcelain").empty?
+      !Cmd.execute('git status --porcelain').empty?
     end
   end
 end

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/pmd/pmd-regression-tester/issues", "homepage_uri" => "https://pmd.github.io", "source_code_uri" => "https://github.com/pmd/pmd-regression-tester" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze]
-  s.date = "2020-11-25"
+  s.date = "2020-11-28"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@pmd-code.org".freeze, "djydewang@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency(%q<slop>.freeze, ["~> 4.6"])
     s.add_runtime_dependency(%q<differ>.freeze, ["~> 0.1"])
     s.add_runtime_dependency(%q<rufus-scheduler>.freeze, ["~> 3.5"])
+    s.add_runtime_dependency(%q<logger-colors>.freeze, ["~> 1.0"])
     s.add_development_dependency(%q<hoe-bundler>.freeze, ["~> 1.5"])
     s.add_development_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
     s.add_development_dependency(%q<minitest>.freeze, ["~> 5.10"])
@@ -46,6 +47,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<slop>.freeze, ["~> 4.6"])
     s.add_dependency(%q<differ>.freeze, ["~> 0.1"])
     s.add_dependency(%q<rufus-scheduler>.freeze, ["~> 3.5"])
+    s.add_dependency(%q<logger-colors>.freeze, ["~> 1.0"])
     s.add_dependency(%q<hoe-bundler>.freeze, ["~> 1.5"])
     s.add_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
     s.add_dependency(%q<minitest>.freeze, ["~> 5.10"])

--- a/test/integration_test_runner.rb
+++ b/test/integration_test_runner.rb
@@ -56,10 +56,11 @@ class IntegrationTestRunner < Test::Unit::TestCase
   end
 
   def test_online_mode
-    # This test depends on the file test_branch_2-baseline.zip being available on sourceforge:
-    # https://sourceforge.net/projects/pmd/files/pmd-regression-tester/test_branch_2-baseline.zip/download
+    # This test depends on the file test_branch_2-baseline.zip being available at:
+    # https://pmd-code.org/pmd-regression-tester/test_branch_2-baseline.zip
     base_branch = 'test_branch_2'
-    argv = "-r target/repositories/pmd -m online -b #{base_branch} -p pmd_releases/6.7.0"
+    argv = "-r target/repositories/pmd -m online -b #{base_branch} -p pmd_releases/6.7.0 " \
+        '--baseline-download-url https://pmd-code.org/pmd-regression-tester/'
 
     system("bundle exec bin/pmdtester #{argv}")
 
@@ -76,15 +77,16 @@ class IntegrationTestRunner < Test::Unit::TestCase
   end
 
   def test_online_mode_different_project_list_and_config
-    # This test depends on the file pmd_releases_6.6.0-baseline.zip being available on sourceforge:
-    # https://sourceforge.net/projects/pmd/files/pmd-regression-tester/pmd_releases_6.6.0-baseline.zip/download
+    # This test depends on the file pmd_releases_6.6.0-baseline.zip being available at:
+    # https://pmd-code.org/pmd-regression-tester/pmd_releases_6.6.0-baseline.zip
     argv = '--local-git-repo target/repositories/pmd '\
            '--mode online '\
            '--base-branch pmd_releases/6.6.0 '\
            '--patch-branch pmd_releases/6.7.0 '\
            '--patch-config test/resources/integration_test_runner/patch-config.xml '\
            '--list-of-project test/resources/integration_test_runner/project-list.xml '\
-           '--auto-gen-config'
+           '--auto-gen-config ' \
+           '--baseline-download-url https://pmd-code.org/pmd-regression-tester/'
 
     system("bundle exec bin/pmdtester #{argv}")
 

--- a/test/resources/project-test.xml
+++ b/test/resources/project-test.xml
@@ -8,7 +8,7 @@ xsi:noNamespaceSchemaLocation="projectlist_1_1_0.xsd">
     <name>checkstyle</name>
     <type>git</type>
     <connection>https://github.com/checkstyle/checkstyle</connection>
-    <tag>checkstyle-8.0</tag>
+    <tag>checkstyle-8.10</tag>
     <exclude-pattern>.*/target/test-classes/com/puppycrawl/tools/checkstyle/.*</exclude-pattern>
     <exclude-pattern>.*/target/generated-sources/.*</exclude-pattern>
 
@@ -17,7 +17,9 @@ if test -e classpath.txt; then
   exit
 fi
 
-mvn test-compile
+set -e
+
+mvn clean test-compile
 mvn dependency:build-classpath -DincludeScope=test -Dmdep.outputFile=classpath.txt
 ]]></build-command>
     <auxclasspath-command>echo -n "$(pwd)/target/classes:$(pwd)/target/test-classes:"; cat classpath.txt</auxclasspath-command>

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -7,11 +7,19 @@ class TestPmdReportBuilder < Test::Unit::TestCase
   def setup
     # pmd version that is simulated in tests when pmd should be built
     @pmd_version = '6.10.0-SNAPSHOT'
+  end
 
+  def teardown
+    pmd_repo = 'target/repositories/pmd'
     # pre-built PMD binary
-    pmd_binary = "target/repositories/pmd/pmd-dist/target/pmd-bin-#{@pmd_version}.zip"
-
+    pmd_binary = "#{pmd_repo}/pmd-dist/target/pmd-bin-#{@pmd_version}.zip"
     File.unlink pmd_binary if File.exist? pmd_binary
+
+    # only deleting empty directories in order to leave pmd_repo intact
+    # for local dev environment, where a local pmd clone might already exist
+    ["#{pmd_repo}/pmd-dist/target", "#{pmd_repo}/pmd-dist", pmd_repo].each do |d|
+      Dir.unlink(d) if Dir.exist?(d) && Dir.empty?(d)
+    end
   end
 
   def test_build_skip

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -104,8 +104,8 @@ class TestPmdReportBuilder < Test::Unit::TestCase
   def record_expectations(sha1_head, sha1_base, zip_file_exists)
     Dir.stubs(:getwd).returns('current-dir').once
     Dir.stubs(:chdir).with('target/repositories/pmd').yields.once
-    PmdTester::Cmd.stubs(:execute).with('git rev-parse HEAD').returns(sha1_head).once
-    PmdTester::Cmd.stubs(:execute).with('git rev-parse master').returns(sha1_base).once
+    PmdTester::Cmd.stubs(:execute).with('git rev-parse HEAD^{commit}').returns(sha1_head).once
+    PmdTester::Cmd.stubs(:execute).with('git rev-parse master^{commit}').returns(sha1_base).once
     PmdTester::Cmd.stubs(:execute).with('./mvnw -q -Dexec.executable="echo" ' \
                   "-Dexec.args='${project.version}' " \
                   '--non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec')
@@ -116,7 +116,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
   end
 
   def record_expecations_after_build
-    PmdTester::Cmd.stubs(:execute).with('git rev-parse HEAD').returns('sha1abc').once
+    PmdTester::Cmd.stubs(:execute).with('git rev-parse HEAD^{commit}').returns('sha1abc').once
     PmdTester::Cmd.stubs(:execute).with('git log -1 --pretty=%B').returns('the commit message').once
     PmdTester::Cmd.stubs(:execute).with('unzip -qo pmd-dist/target/pmd-bin-6.10.0-SNAPSHOT.zip' \
                   ' -d current-dir/target').once

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -11,7 +11,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     options = PmdTester::Options.new(argv)
 
     record_expectations('sha1abc', 'sha1abc', true)
-    record_expecations_after_build
+    record_expectations_after_build
 
     PmdTester::PmdReportBuilder
       .new(projects, options, options.base_config, options.base_branch)
@@ -30,7 +30,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
                   .returns('checked out branch master').once
     PmdTester::Cmd.stubs(:execute).with('./mvnw clean package -Dmaven.test.skip=true' \
                   ' -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -Dcheckstyle.skip=true').once
-    record_expecations_after_build
+    record_expectations_after_build
 
     PmdTester::PmdReportBuilder
       .new(projects, options, options.base_config, options.base_branch)
@@ -115,7 +115,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
         .returns(zip_file_exists).once
   end
 
-  def record_expecations_after_build
+  def record_expectations_after_build
     PmdTester::Cmd.stubs(:execute).with('git rev-parse HEAD^{commit}').returns('sha1abc').once
     PmdTester::Cmd.stubs(:execute).with('git log -1 --pretty=%B').returns('the commit message').once
     PmdTester::Cmd.stubs(:execute).with('unzip -qo pmd-dist/target/pmd-bin-6.10.0-SNAPSHOT.zip' \


### PR DESCRIPTION
This is a continuation of #65 

PMD builds are labeled now with this pattern: `target/pmd-bin-<version>-<branch_name>-<sha1>`. Although technically not necessary, I find the information from version and branch still useful, so I added these in addition to the commit sha1.
This improves integration tests locally, since PMD doesn't need to be rebuild always.

For CI, we still look at `pmd-dist/target/pmd-bin-<version>.zip` and reuse this build. In CI, that's no problem, because it runs always with a fresh workspace, only locally it could be a problem (taking the wrong build).

It takes a couple of commits from #78 as well, e.g. fixing sha1 commits and use pmd-code.org for downloading baselines (sourceforge is still unusable).