### PR TITLE
Dynamically generated rulesets are not applied on diffs

### DIFF
--- a/lib/pmdtester/pmd_report_detail.rb
+++ b/lib/pmdtester/pmd_report_detail.rb
@@ -27,7 +27,7 @@ module PmdTester
         hash = JSON.parse(File.read(report_info_path), symbolize_names: true)
         PmdReportDetail.new(**hash)
       else
-        puts "#{report_info_path} doesn't exist"
+        PmdTester.logger.warn("#{report_info_path} doesn't exist")
         PmdReportDetail.new
       end
     end

--- a/lib/pmdtester/pmd_tester_utils.rb
+++ b/lib/pmdtester/pmd_tester_utils.rb
@@ -39,13 +39,15 @@ module PmdTester
     def compute_project_diffs(projects, base_branch, patch_branch, filter_set = nil)
       projects.each do |project|
         logger.info "Preparing report for #{project.name}"
+        logger.info "  with filter #{filter_set}" unless filter_set.nil?
         project.compute_report_diff(base_branch, patch_branch, filter_set)
       end
     end
 
     # Build the diff reports and write them all
-    def build_html_reports(projects, base_branch_details, patch_branch_details)
-      compute_project_diffs(projects, base_branch_details.branch_name, patch_branch_details.branch_name)
+    def build_html_reports(projects, base_branch_details, patch_branch_details, filter_set = nil)
+      compute_project_diffs(projects, base_branch_details.branch_name, patch_branch_details.branch_name,
+                            filter_set)
 
       SummaryReportBuilder.new.write_all_projects(projects,
                                                   base_branch_details,

--- a/lib/pmdtester/report_diff.rb
+++ b/lib/pmdtester/report_diff.rb
@@ -33,6 +33,10 @@ module PmdTester
         'patch_total' => patch_total
       }
     end
+
+    def to_s
+      "RunningDiffCounters[#{to_h}]"
+    end
   end
 
   # Simple info about a rule, collected by the report xml parser
@@ -75,6 +79,12 @@ module PmdTester
       @errors_by_file = report_document.errors
       @configerrors_by_rule = report_document.configerrors
       @infos_by_rule = report_document.infos_by_rules
+
+      PmdTester.logger.debug("Loaded #{@violations_by_file.total_size} violations " \
+                             "in #{@violations_by_file.num_files} files")
+      PmdTester.logger.debug("Loaded #{@errors_by_file.total_size} errors " \
+                             "in #{@errors_by_file.num_files} files")
+      PmdTester.logger.debug("Loaded #{@configerrors_by_rule.size} config errors")
     end
 
     def initialize_empty

--- a/lib/pmdtester/runner.rb
+++ b/lib/pmdtester/runner.rb
@@ -64,7 +64,7 @@ module PmdTester
       patch_branch_details = create_pmd_report(config: @options.patch_config, branch: @options.patch_branch)
 
       base_branch_details = PmdBranchDetail.load(@options.base_branch, logger)
-      build_html_reports(@projects, base_branch_details, patch_branch_details)
+      build_html_reports(@projects, base_branch_details, patch_branch_details, @options.filter_set)
     end
 
     def determine_project_list_for_online_mode(baseline_path)

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/pmd/pmd-regression-tester/issues", "homepage_uri" => "https://pmd.github.io", "source_code_uri" => "https://github.com/pmd/pmd-regression-tester" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze, "Cl\u00E9ment Fournier".freeze]
-  s.date = "2021-01-07"
+  s.date = "2021-01-14"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@pmd-code.org".freeze, "djydewang@gmail.com".freeze, "clement.fournier76@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]

--- a/test/resources/summary_report_builder/base-checkstyle-report.xml
+++ b/test/resources/summary_report_builder/base-checkstyle-report.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pmd xmlns="http://pmd.sourceforge.net/report/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd"
+    version="6.3.0-SNAPSHOT" timestamp="2018-04-16T22:41:45.065">
+<file name="Same1.java">
+<violation beginline="7" endline="8" begincolumn="12" endcolumn="5" rule="UncommentedEmptyConstructor" ruleset="Documentation" class="Null" method="Null" externalInfoUrl="http://pmd.sourceforge.net/snapshot/pmd_rules_java_documentation.html#uncommentedemptyconstructor" priority="3">
+  This is filtered out.
+</violation>
+</file>
+<file name="Base1.java">
+<violation beginline="51" endline="51" begincolumn="9" endcolumn="46" rule="AbstractClassWithoutAbstractMethod" ruleset="Best Practices" package="org.springframework.aop" class="Pointcut" variable="TRUE" externalInfoUrl="http://pmd.sourceforge.net/snapshot/pmd_rules_java_codestyle.html#fielddeclarationsshouldbeatstartofclass" priority="3">
+  This stays in the report.
+</violation>
+</file>
+<file name="Same2.java">
+<violation beginline="30" endline="73" begincolumn="1" endcolumn="1" rule="ClassWithOnlyPrivateConstructorsShouldBeFinal" ruleset="Design" package="org.springframework.aop" externalInfoUrl="http://pmd.sourceforge.net/snapshot/pmd_rules_java_design.html#classwithonlyprivateconstructorsshouldbefinal" priority="1">
+  This is filtered out.
+</violation>
+</file>
+</pmd>

--- a/test/resources/summary_report_builder/base_branch_info.json
+++ b/test/resources/summary_report_builder/base_branch_info.json
@@ -1,7 +1,7 @@
 {
     "branch_last_sha":"test sha",
     "branch_last_message":"test message",
-    "branch_name":"test_branch",
+    "branch_name":"base_branch",
     "execution_time":121.123,
     "jdk_version":"test version",
     "language":"test language",

--- a/test/resources/summary_report_builder/expected_filtered_index.html
+++ b/test/resources/summary_report_builder/expected_filtered_index.html
@@ -30,8 +30,10 @@
                     <td class="item">Branch info</td>
                     <td><a href="https://github.com/pmd/pmd/tree/test+sha">base_branch test sha</a>: test message</td>
                     <td>
-                        <a href="https://github.com/pmd/pmd/tree/test+sha">base_branch test sha</a>: test message
+                        <a href="https://github.com/pmd/pmd/tree/test+sha">patch_branch test sha</a>: test message
+                        
                         <span class="external-link-secondary"><a href="https://github.com/pmd/pmd/pull/42">PR #42</a></span>
+                        
                         <span class="external-link-secondary"><a href="https://github.com/pmd/pmd/compare/base_branch...test+sha">[Compare]</a></span>
                     </td>
                 </tr>
@@ -80,9 +82,9 @@
                 </thead>
                 <tbody>
 
+                
 
-
-
+                
                 <tr>
                     <td class="project-header"><a href="./checkstyle/index.html">checkstyle</a></td>
                     <td>master</td>
@@ -108,7 +110,7 @@
 
 </td>
                 </tr>
-
+                
                 <tr>
                     <td class="project-header"><a href="./openjdk10/index.html">openjdk10</a></td>
                     <td>master</td>
@@ -134,7 +136,7 @@
 
 </td>
                 </tr>
-
+                
                 <tr>
                     <td class="project-header"><a href="./spring-framework/index.html">spring-framework</a></td>
                     <td>v5.0.6.RELEASE</td>
@@ -160,7 +162,7 @@
 
 </td>
                 </tr>
-
+                
                 </tbody>
             </table>
         </div>

--- a/test/resources/summary_report_builder/patch-checkstyle-report.xml
+++ b/test/resources/summary_report_builder/patch-checkstyle-report.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pmd xmlns="http://pmd.sourceforge.net/report/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd"
+    version="6.3.0-SNAPSHOT" timestamp="2018-04-16T22:41:45.065">
+<file name="Base1.java">
+<violation beginline="51" endline="51" begincolumn="9" endcolumn="46" rule="AbstractClassWithoutAbstractMethod" ruleset="Best Practices" package="org.springframework.aop" class="Pointcut" variable="TRUE" externalInfoUrl="http://pmd.sourceforge.net/snapshot/pmd_rules_java_codestyle.html#fielddeclarationsshouldbeatstartofclass" priority="3">
+  This stays in the report.
+</violation>
+</file>
+</pmd>

--- a/test/resources/summary_report_builder/patch_branch_info.json
+++ b/test/resources/summary_report_builder/patch_branch_info.json
@@ -1,0 +1,9 @@
+{
+    "branch_last_sha":"test sha",
+    "branch_last_message":"test message",
+    "branch_name":"patch_branch",
+    "execution_time":121.123,
+    "jdk_version":"test version",
+    "language":"test language",
+    "pull_request":42
+}

--- a/test/test_diff_builder.rb
+++ b/test/test_diff_builder.rb
@@ -37,6 +37,32 @@ class TestDiffBuilder < Test::Unit::TestCase
     # assert_equal('00:00:56', diffs_report.diff_execution_time)
   end
 
+  def test_violation_diffs_with_filter
+    base_report_path = 'test/resources/diff_builder/test_violation_diffs_base.xml'
+    patch_report_path = 'test/resources/diff_builder/test_violation_diffs_patch.xml'
+    filter_set = Set['codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass']
+    diffs_report = build_report_diff(base_report_path, patch_report_path,
+                                     BASE_REPORT_INFO_PATH, PATCH_REPORT_INFO_PATH,
+                                     filter_set)
+    violation_diffs = diffs_report.violation_diffs_by_file
+    keys = violation_diffs.keys
+
+    assert_counters_empty(diffs_report.error_counts)
+    assert_counters_eq(diffs_report.violation_counts,
+                       base_total: 2, patch_total: 8, changed_total: 8)
+    assert_changes_eq(diffs_report.violation_counts,
+                      removed: 1, added: 7, changed: 0)
+
+    assert_equal('Base1.java', keys[0])
+    assert_equal('SameFileNameWithDiffViolations.java', keys[1])
+    assert_equal(2, violation_diffs[keys[1]].size)
+    assert_equal('Same1.java', keys[2])
+    assert_equal('Patch1.java', keys[3])
+    assert_equal('Patch2.java', keys[4])
+    assert_equal('Patch3.java', keys[5])
+    assert_equal('Same2.java', keys[6])
+  end
+
   def test_error_diffs
     base_report_path = 'test/resources/diff_builder/test_error_diffs_base.xml'
     patch_report_path = 'test/resources/diff_builder/test_error_diffs_patch.xml'

--- a/test/test_summary_report_builder.rb
+++ b/test/test_summary_report_builder.rb
@@ -13,16 +13,41 @@ class TestSummaryReportBuilder < Test::Unit::TestCase
   def test_summary_report_builder
     projects = PmdTester::ProjectsParser.new.parse('test/resources/project-list.xml')
 
-    branch_path = 'target/reports/test_branch'
-    FileUtils.mkdir_p(branch_path)
+    base_path = 'target/reports/base_branch'
+    FileUtils.mkdir_p(base_path)
     test_resources_path = 'test/resources/summary_report_builder'
-    FileUtils.cp("#{test_resources_path}/branch_info.json", branch_path)
-    FileUtils.cp("#{test_resources_path}/empty_config.xml", "#{branch_path}/config.xml")
+    FileUtils.cp("#{test_resources_path}/base_branch_info.json", "#{base_path}/branch_info.json")
+    FileUtils.cp("#{test_resources_path}/empty_config.xml", "#{base_path}/config.xml")
 
-    branch = PmdTester::PmdBranchDetail.load('test_branch', nil)
+    branch = PmdTester::PmdBranchDetail.load('base_branch', nil)
     build_html_reports(projects, branch, branch)
 
     assert_file_equals('test/resources/summary_report_builder/expected_index.html',
+                       'target/reports/diff/index.html')
+  end
+
+  def test_summary_report_builder_with_filter
+    projects = PmdTester::ProjectsParser.new.parse('test/resources/project-list.xml')
+
+    base_path = 'target/reports/base_branch'
+    FileUtils.mkdir_p(base_path)
+    patch_path = 'target/reports/patch_branch'
+    FileUtils.mkdir_p(patch_path)
+    test_resources_path = 'test/resources/summary_report_builder'
+    FileUtils.cp("#{test_resources_path}/base_branch_info.json", "#{base_path}/branch_info.json")
+    FileUtils.cp("#{test_resources_path}/patch_branch_info.json", "#{patch_path}/branch_info.json")
+    FileUtils.cp("#{test_resources_path}/empty_config.xml", "#{base_path}/config.xml")
+    FileUtils.cp("#{test_resources_path}/empty_config.xml", "#{patch_path}/config.xml")
+    FileUtils.mkdir_p("#{base_path}/checkstyle")
+    FileUtils.cp("#{test_resources_path}/base-checkstyle-report.xml", "#{base_path}/checkstyle/pmd_report.xml")
+    FileUtils.mkdir_p("#{patch_path}/checkstyle")
+    FileUtils.cp("#{test_resources_path}/patch-checkstyle-report.xml", "#{patch_path}/checkstyle/pmd_report.xml")
+
+    branch = PmdTester::PmdBranchDetail.load('base_branch', nil)
+    patch = PmdTester::PmdBranchDetail.load('patch_branch', nil)
+    build_html_reports(projects, branch, patch, Set['bestpractices.xml/AbstractClassWithoutAbstractMethod'])
+
+    assert_file_equals('test/resources/summary_report_builder/expected_filtered_index.html',
                        'target/reports/diff/index.html')
   end
 end


### PR DESCRIPTION
The filter was correctly determined and used when the PMD report
has been created. That resulted in the patch report having less
violations than the baseline (which was created with full config).
For diffing, the baseline also needs to have the filter applied.

This fixes the problem "Unexpected diff report" mentioned in pmd/pmd#3000.
