### PR TITLE
Summary hash uses wrong key names

### DIFF
--- a/lib/pmdtester/builders/project_hasher.rb
+++ b/lib/pmdtester/builders/project_hasher.rb
@@ -9,9 +9,9 @@ module PmdTester
 
     def report_diff_to_h(rdiff)
       {
-        'violation_counts' => rdiff.violation_counts.to_h,
-        'error_counts' => rdiff.error_counts.to_h,
-        'configerror_counts' => rdiff.configerror_counts.to_h,
+        'violation_counts' => rdiff.violation_counts.to_h.transform_keys(&:to_s),
+        'error_counts' => rdiff.error_counts.to_h.transform_keys(&:to_s),
+        'configerror_counts' => rdiff.configerror_counts.to_h.transform_keys(&:to_s),
 
         'base_execution_time' => PmdReportDetail.convert_seconds(rdiff.base_report.exec_time),
         'patch_execution_time' => PmdReportDetail.convert_seconds(rdiff.patch_report.exec_time),

--- a/lib/pmdtester/report_diff.rb
+++ b/lib/pmdtester/report_diff.rb
@@ -26,11 +26,11 @@ module PmdTester
 
     def to_h
       {
-        'changed' => changed,
-        'new' => new,
-        'removed' => removed,
-        'base_total' => base_total,
-        'patch_total' => patch_total
+        changed: changed,
+        new: new,
+        removed: removed,
+        base_total: base_total,
+        patch_total: patch_total
       }
     end
   end
@@ -125,7 +125,7 @@ module PmdTester
         {
           'name' => rule,
           'info_url' => @rule_infos_union[rule].info_url,
-          **counters.to_h
+          **counters.to_h.transform_keys(&:to_s)
         }
       end
     end

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/pmd/pmd-regression-tester/issues", "homepage_uri" => "https://pmd.github.io", "source_code_uri" => "https://github.com/pmd/pmd-regression-tester" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze, "Cl\u00E9ment Fournier".freeze]
-  s.date = "2021-01-07"
+  s.date = "2021-01-14"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@pmd-code.org".freeze, "djydewang@gmail.com".freeze, "clement.fournier76@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -140,8 +140,17 @@ class TestRunner < Test::Unit::TestCase
 
   def assert_summarized_diffs(diffs)
     refute_nil(diffs)
-    refute_nil(diffs[:errors])
-    refute_nil(diffs[:violations])
-    refute_nil(diffs[:configerrors])
+    assert_counters(diffs[:errors])
+    assert_counters(diffs[:violations])
+    assert_counters(diffs[:configerrors])
+  end
+
+  def assert_counters(counter)
+    refute_nil(counter)
+    refute_nil(counter[:changed])
+    refute_nil(counter[:new])
+    refute_nil(counter[:removed])
+    refute_nil(counter[:base_total])
+    refute_nil(counter[:patch_total])
   end
 end


### PR DESCRIPTION
As documented in History.md, the keys of the hash returned by Runner must be symbols,
e.g.

```
summary = PmdTester::Runner.new(argv).run
puts summary
# {:errors=>{:new=>0, :removed=>0}, :violations=>{:new=>0, :removed=>0, :changed=>0}, :configerrors=>{:new=>0, :removed=>0}}
```

This fixes the problem "the summary numbers are missing" mentioned on pmd/pmd#3000.