### PR TITLE
Explicitly install ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('pmdtester.gemspec') }}
         restore-keys: |
           ${{ runner.os }}-
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
     - name: Setup Environment
       shell: bash
       run: |


### PR DESCRIPTION
This hopefully correctly sets the paths so that
gems can be installed for the current user.

gem shouldn't issue the following warning anymore:

  You don't have /home/runner/.gem/ruby/2.7.0/bin in your PATH,
  gem executables will not run.