### PR TITLE
Make stdout/stderr and exit code available

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,8 @@
 
 ## Enhancements
 
+* [#109](https://github.com/pmd/pmd-regression-tester/issues/109): Make stdout/stderr and exit code available
+
 ## Fixed Issues
 
 ## External Contributions

--- a/lib/pmdtester/builders/liquid_renderer.rb
+++ b/lib/pmdtester/builders/liquid_renderer.rb
@@ -60,6 +60,11 @@ module PmdTester
       # copy original pmd reports
       copy_file("#{root}/base_pmd_report.xml", project.report_diff.base_report.file)
       copy_file("#{root}/patch_pmd_report.xml", project.report_diff.patch_report.file)
+      # copy stdout and stderr outputs
+      copy_file("#{root}/base_stdout.txt", "#{project.report_diff.base_report.report_folder}/stdout.txt")
+      copy_file("#{root}/base_stderr.txt", "#{project.report_diff.base_report.report_folder}/stderr.txt")
+      copy_file("#{root}/patch_stdout.txt", "#{project.report_diff.patch_report.report_folder}/stdout.txt")
+      copy_file("#{root}/patch_stderr.txt", "#{project.report_diff.patch_report.report_folder}/stderr.txt")
       # render full pmd reports
       write_file("#{root}/base_pmd_report.html",
                  render_liquid('project_pmd_report.html', pmd_report_liquid_env(project, BASE)))

--- a/lib/pmdtester/builders/liquid_renderer.rb
+++ b/lib/pmdtester/builders/liquid_renderer.rb
@@ -120,6 +120,7 @@ module PmdTester
 
         'execution_time' => PmdReportDetail.convert_seconds(report.exec_time),
         'timestamp' => report.timestamp,
+        'exit_code' => report.exit_code,
 
         'rules' => report.rule_summaries,
         'errors' => report.errors_by_file.all_values.map { |e| error_to_hash(e, project) },

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -25,7 +25,7 @@ module PmdTester
     def get_pmd_binary_file
       logger.info "#{@pmd_branch_name}: Start packaging PMD"
       Dir.chdir(@local_git_repo) do
-        build_branch_sha = Cmd.execute("git rev-parse #{@pmd_branch_name}^{commit}")
+        build_branch_sha = Cmd.execute_successfully("git rev-parse #{@pmd_branch_name}^{commit}")
 
         checkout_build_branch # needs a clean working tree, otherwise fails
 
@@ -70,28 +70,28 @@ module PmdTester
                       ' -Dcheckstyle.skip=true' \
                       ' -Dpmd.skip=true' \
                       ' -T1C -B'
-        Cmd.execute(package_cmd)
+        Cmd.execute_successfully(package_cmd)
       end
 
       logger.info "#{@pmd_branch_name}: Extracting the zip"
-      Cmd.execute("unzip -qo #{pmd_dist_target} -d pmd-dist/target/exploded")
-      Cmd.execute("mv pmd-dist/target/exploded/pmd-bin-#{@pmd_version} #{into_dir}")
+      Cmd.execute_successfully("unzip -qo #{pmd_dist_target} -d pmd-dist/target/exploded")
+      Cmd.execute_successfully("mv pmd-dist/target/exploded/pmd-bin-#{@pmd_version} #{into_dir}")
     end
 
     def determine_pmd_version
       version_cmd = "./mvnw -q -Dexec.executable=\"echo\" -Dexec.args='${project.version}' " \
                     '--non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec'
-      Cmd.execute(version_cmd)
+      Cmd.execute_successfully(version_cmd)
     end
 
     def get_last_commit_sha
       get_last_commit_sha_cmd = 'git rev-parse HEAD^{commit}'
-      Cmd.execute(get_last_commit_sha_cmd)
+      Cmd.execute_successfully(get_last_commit_sha_cmd)
     end
 
     def get_last_commit_message
       get_last_commit_message_cmd = 'git log -1 --pretty=%B'
-      Cmd.execute(get_last_commit_message_cmd)
+      Cmd.execute_successfully(get_last_commit_message_cmd)
     end
 
     def generate_pmd_report(project)
@@ -167,7 +167,7 @@ module PmdTester
     def checkout_build_branch
       logger.info "#{@pmd_branch_name}: Checking out the branch"
       # note that this would fail if the tree is dirty
-      Cmd.execute("git checkout #{@pmd_branch_name}")
+      Cmd.execute_successfully("git checkout #{@pmd_branch_name}")
 
       # determine the version
       @pmd_version = determine_pmd_version
@@ -193,7 +193,7 @@ module PmdTester
     end
 
     def wd_has_dirty_git_changes
-      !Cmd.execute('git status --porcelain').empty?
+      !Cmd.execute_successfully('git status --porcelain').empty?
     end
 
     def should_use_long_cli_options

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -110,7 +110,7 @@ module PmdTester
         logger.warn "#{@pmd_branch_name}: Skipping PMD run - report " \
                     "#{project.get_pmd_report_path(@pmd_branch_name)} already exists"
       else
-        _stdout, _stderr, status = Cmd.execute(pmd_cmd)
+        status = Cmd.execute(pmd_cmd, project.get_project_target_dir(@pmd_branch_name))
         exit_code = status.exitstatus
       end
       end_time = Time.now

--- a/lib/pmdtester/builders/project_builder.rb
+++ b/lib/pmdtester/builders/project_builder.rb
@@ -30,7 +30,7 @@ module PmdTester
           # once but may be used with several tags.
           clone_cmd = "git clone --no-single-branch --depth 1 #{project.connection} #{path}"
 
-          Cmd.execute(clone_cmd)
+          Cmd.execute_successfully(clone_cmd)
         end
 
         Dir.chdir(path) do
@@ -87,7 +87,7 @@ module PmdTester
         if command.start_with?('#!')
           shell = command.lines[0].chomp[2..] # remove leading "#!"
         end
-        stdout = Cmd.execute("#{shell} #{script.path}")
+        stdout = Cmd.execute_successfully("#{shell} #{script.path}")
       ensure
         script.unlink
       end
@@ -99,7 +99,7 @@ module PmdTester
 
       reset_cmd = "git checkout #{tag}; git reset --hard #{tag}"
 
-      Cmd.execute(reset_cmd)
+      Cmd.execute_successfully(reset_cmd)
     end
   end
 end

--- a/lib/pmdtester/builders/project_hasher.rb
+++ b/lib/pmdtester/builders/project_hasher.rb
@@ -21,6 +21,9 @@ module PmdTester
         'base_timestamp' => rdiff.base_report.timestamp,
         'patch_timestamp' => rdiff.patch_report.timestamp,
 
+        'base_exit_code' => rdiff.base_report.exit_code,
+        'patch_exit_code' => rdiff.patch_report.exit_code,
+
         'rule_diffs' => rdiff.rule_summaries
       }
     end

--- a/lib/pmdtester/builders/rule_set_builder.rb
+++ b/lib/pmdtester/builders/rule_set_builder.rb
@@ -176,7 +176,7 @@ module PmdTester
 
         # We only need to support git here, since PMD's repo is using git.
         diff_cmd = "git diff --name-only #{base}..#{patch} #{filepath_filter}"
-        filenames = Cmd.execute(diff_cmd)
+        filenames = Cmd.execute_successfully(diff_cmd)
       end
       filenames.split("\n")
     end

--- a/lib/pmdtester/cmd.rb
+++ b/lib/pmdtester/cmd.rb
@@ -7,9 +7,23 @@ module PmdTester
   class Cmd
     extend PmdTester
 
-    def self.execute(cmd)
+    #
+    # Executes the given command and returns the process status.
+    # stdout and stderr are written to the files "stdout.txt" and "stderr.txt"
+    # in path.
+    #
+    def self.execute(cmd, path)
       stdout, stderr, status = internal_execute(cmd)
-      [stdout, stderr, status]
+
+      file = File.new("#{path}/stdout.txt", 'w')
+      file.puts stdout
+      file.close
+
+      file = File.new("#{path}/stderr.txt", 'w')
+      file.puts stderr
+      file.close
+
+      status
     end
 
     def self.execute_successfully(cmd)

--- a/lib/pmdtester/cmd.rb
+++ b/lib/pmdtester/cmd.rb
@@ -6,9 +6,21 @@ module PmdTester
   # Containing the common method for executing shell command
   class Cmd
     extend PmdTester
+
     def self.execute(cmd)
-      stdout, _stderr, _status = internal_execute(cmd)
-      stdout&.chomp!
+      stdout, stderr, status = internal_execute(cmd)
+      [stdout, stderr, status]
+    end
+
+    def self.execute_successfully(cmd)
+      stdout, stderr, status = internal_execute(cmd)
+
+      unless status.success?
+        logger.error stdout
+        logger.error stderr
+        raise CmdException.new(cmd, stdout, stderr, status)
+      end
+
       stdout
     end
 
@@ -22,14 +34,12 @@ module PmdTester
 
       stdout, stderr, status = Open3.capture3("#{cmd};")
 
-      logger.debug stdout
-      unless status.success?
-        logger.error stdout
-        logger.error stderr
-        raise CmdException.new(cmd, stderr)
-      end
+      logger.debug "status: #{status}"
+      logger.debug "stdout: #{stdout}"
+      logger.debug "stderr: #{stderr}"
 
       stdout&.chomp!
+      stderr&.chomp!
 
       [stdout, stderr, status]
     end
@@ -40,15 +50,19 @@ module PmdTester
   # The exception should be raised when the shell command failed.
   class CmdException < StandardError
     attr_reader :cmd
+    attr_reader :stdout
     attr_reader :error
+    attr_reader :status
     attr_reader :message
 
     COMMON_MSG = 'An error occurred while executing the shell command'
 
-    def initialize(cmd, error)
+    def initialize(cmd, stdout, error, status)
       @cmd = cmd
+      @stdout = stdout
       @error = error
-      @message = "#{COMMON_MSG} '#{cmd}'"
+      @status = status
+      @message = "#{COMMON_MSG} '#{cmd}' #{status}"
     end
   end
 end

--- a/lib/pmdtester/pmd_report_detail.rb
+++ b/lib/pmdtester/pmd_report_detail.rb
@@ -8,15 +8,22 @@ module PmdTester
     attr_accessor :execution_time
     attr_accessor :timestamp
     attr_accessor :working_dir
+    attr_accessor :exit_code
 
-    def initialize(execution_time: 0, timestamp: '', working_dir: Dir.getwd)
+    def initialize(execution_time: 0, timestamp: '', working_dir: Dir.getwd, exit_code: nil)
       @execution_time = execution_time
       @timestamp = timestamp
       @working_dir = working_dir
+      @exit_code = exit_code.nil? ? '?' : exit_code.to_s
     end
 
     def save(report_info_path)
-      hash = { execution_time: @execution_time, timestamp: @timestamp, working_dir: @working_dir }
+      hash = {
+        execution_time: @execution_time,
+        timestamp: @timestamp,
+        working_dir: @working_dir,
+        exit_code: @exit_code
+      }
       file = File.new(report_info_path, 'w')
       file.puts JSON.generate(hash)
       file.close
@@ -34,6 +41,13 @@ module PmdTester
 
     def format_execution_time
       self.class.convert_seconds(@execution_time)
+    end
+
+    def self.create(execution_time: 0, timestamp: '', working_dir: Dir.getwd, exit_code: nil, report_info_path:)
+      detail = PmdReportDetail.new(execution_time: execution_time, timestamp: timestamp,
+                                   working_dir: working_dir, exit_code: exit_code)
+      detail.save(report_info_path)
+      detail
     end
 
     # convert seconds into HH::MM::SS

--- a/lib/pmdtester/pmd_tester_utils.rb
+++ b/lib/pmdtester/pmd_tester_utils.rb
@@ -32,7 +32,8 @@ module PmdTester
         file: report_file,
 
         timestamp: report_details.timestamp,
-        exec_time: report_details.execution_time
+        exec_time: report_details.execution_time,
+        exit_code: report_details.exit_code
       )
     end
 

--- a/lib/pmdtester/project.rb
+++ b/lib/pmdtester/project.rb
@@ -123,6 +123,9 @@ module PmdTester
                                            get_report_info_path(base_branch),
                                            get_report_info_path(patch_branch),
                                            filter_set)
+
+      report_diff.base_report.report_folder = get_project_target_dir(base_branch)
+      report_diff.patch_report.report_folder = get_project_target_dir(patch_branch)
     end
   end
 end

--- a/lib/pmdtester/report_diff.rb
+++ b/lib/pmdtester/report_diff.rb
@@ -60,6 +60,8 @@ module PmdTester
                 :exit_code,
                 :file
 
+    attr_accessor :report_folder
+
     def initialize(report_document: nil,
                    file: '',
                    exec_time: 0,
@@ -111,6 +113,7 @@ module PmdTester
       @violations_by_file = CollectionByFile.new
       @errors_by_file = CollectionByFile.new
       @configerrors_by_rule = {}
+      @report_folder = ''
     end
   end
 

--- a/lib/pmdtester/report_diff.rb
+++ b/lib/pmdtester/report_diff.rb
@@ -57,17 +57,20 @@ module PmdTester
                 :configerrors_by_rule,
                 :exec_time,
                 :timestamp,
+                :exit_code,
                 :file
 
     def initialize(report_document: nil,
                    file: '',
                    exec_time: 0,
-                   timestamp: '0')
+                   timestamp: '0',
+                   exit_code: '?')
       initialize_empty
       initialize_with_report_document report_document unless report_document.nil?
       @exec_time = exec_time
       @timestamp = timestamp
       @file = file
+      @exit_code = exit_code
     end
 
     def self.empty

--- a/lib/pmdtester/runner.rb
+++ b/lib/pmdtester/runner.rb
@@ -97,8 +97,8 @@ module PmdTester
       unzip_cmd = "unzip -qo #{zip_filename}"
 
       Dir.chdir(target_path) do
-        Cmd.execute(wget_cmd) unless File.exist?(zip_filename)
-        Cmd.execute(unzip_cmd)
+        Cmd.execute_successfully(wget_cmd) unless File.exist?(zip_filename)
+        Cmd.execute_successfully(unzip_cmd)
       end
 
       "#{target_path}/#{branch_filename}"

--- a/resources/project_diff_report.html
+++ b/resources/project_diff_report.html
@@ -73,8 +73,8 @@
             </tr>
             <tr>
                 <td class="item">Exit Code</td>
-                <td class="base">{{diff.base_exit_code}}</td>
-                <td class="patch">{{diff.patch_exit_code}}</td>
+                <td class="base">{{diff.base_exit_code}} <a href="base_stdout.txt">stdout</a> | <a href="base_stderr.txt">stderr</a></td>
+                <td class="patch">{{diff.patch_exit_code}} <a href="patch_stdout.txt">stdout</a> | <a href="patch_stderr.txt">stderr</a></td>
                 <td class="diff"></td>
             </tr>
             <tr>

--- a/resources/project_diff_report.html
+++ b/resources/project_diff_report.html
@@ -72,6 +72,12 @@
                 <td class="diff"></td>
             </tr>
             <tr>
+                <td class="item">Exit Code</td>
+                <td class="base">{{diff.base_exit_code}}</td>
+                <td class="patch">{{diff.patch_exit_code}}</td>
+                <td class="diff"></td>
+            </tr>
+            <tr>
                 <td class="item">Full Report</td>
                 <td class="base"><a href="base_pmd_report.html">Base PMD Report</a></td>
                 <td class="patch"><a href="patch_pmd_report.html">Patch PMD Report</a></td>

--- a/resources/project_pmd_report.html
+++ b/resources/project_pmd_report.html
@@ -55,7 +55,7 @@
             </tr>
             <tr>
                 <td class="item">Exit Code</td>
-                <td class="{{branch}}">{{report.exit_code}}</td>
+                <td class="{{branch}}">{{report.exit_code}} <a href="{{branch}}_stdout.txt">stdout</a> | <a href="{{branch}}_stderr.txt">stderr</a></td>
             </tr>
             <tr>
                 <td class="item">Full Report</td>

--- a/resources/project_pmd_report.html
+++ b/resources/project_pmd_report.html
@@ -54,6 +54,10 @@
                 <td class="{{branch}}">{{report.timestamp}}</td>
             </tr>
             <tr>
+                <td class="item">Exit Code</td>
+                <td class="{{branch}}">{{report.exit_code}}</td>
+            </tr>
+            <tr>
                 <td class="item">Full Report</td>
                 <td class="{{branch}}"><a href="{{branch}}_pmd_report.xml">{{branch}}_pmd_report.xml</a></td>
             </tr>

--- a/test/resources/html_report_builder/base/stderr.txt
+++ b/test/resources/html_report_builder/base/stderr.txt
@@ -1,0 +1,1 @@
+base stderr

--- a/test/resources/html_report_builder/base/stdout.txt
+++ b/test/resources/html_report_builder/base/stdout.txt
@@ -1,0 +1,1 @@
+base stdout

--- a/test/resources/html_report_builder/base_report_info.json
+++ b/test/resources/html_report_builder/base_report_info.json
@@ -1,1 +1,1 @@
-{"execution_time":121,"timestamp":"base time stamp","working_dir":"SHOULD_BE_REPLACED"}
+{"execution_time":121,"timestamp":"base time stamp","working_dir":"SHOULD_BE_REPLACED","exit_code":"0"}

--- a/test/resources/html_report_builder/expected_diff_report_index.html
+++ b/test/resources/html_report_builder/expected_diff_report_index.html
@@ -90,6 +90,12 @@
                 <td class="diff"></td>
             </tr>
             <tr>
+                <td class="item">Exit Code</td>
+                <td class="base">0</td>
+                <td class="patch">1</td>
+                <td class="diff"></td>
+            </tr>
+            <tr>
                 <td class="item">Full Report</td>
                 <td class="base"><a href="base_pmd_report.html">Base PMD Report</a></td>
                 <td class="patch"><a href="patch_pmd_report.html">Patch PMD Report</a></td>

--- a/test/resources/html_report_builder/expected_diff_report_index.html
+++ b/test/resources/html_report_builder/expected_diff_report_index.html
@@ -91,8 +91,8 @@
             </tr>
             <tr>
                 <td class="item">Exit Code</td>
-                <td class="base">0</td>
-                <td class="patch">1</td>
+                <td class="base">0 <a href="base_stdout.txt">stdout</a> | <a href="base_stderr.txt">stderr</a></td>
+                <td class="patch">1 <a href="patch_stdout.txt">stdout</a> | <a href="patch_stderr.txt">stderr</a></td>
                 <td class="diff"></td>
             </tr>
             <tr>

--- a/test/resources/html_report_builder/expected_empty_diff_report.html
+++ b/test/resources/html_report_builder/expected_empty_diff_report.html
@@ -90,6 +90,12 @@
                 <td class="diff"></td>
             </tr>
             <tr>
+                <td class="item">Exit Code</td>
+                <td class="base">?</td>
+                <td class="patch">?</td>
+                <td class="diff"></td>
+            </tr>
+            <tr>
                 <td class="item">Full Report</td>
                 <td class="base"><a href="base_pmd_report.html">Base PMD Report</a></td>
                 <td class="patch"><a href="patch_pmd_report.html">Patch PMD Report</a></td>

--- a/test/resources/html_report_builder/expected_empty_diff_report.html
+++ b/test/resources/html_report_builder/expected_empty_diff_report.html
@@ -91,8 +91,8 @@
             </tr>
             <tr>
                 <td class="item">Exit Code</td>
-                <td class="base">?</td>
-                <td class="patch">?</td>
+                <td class="base">? <a href="base_stdout.txt">stdout</a> | <a href="base_stderr.txt">stderr</a></td>
+                <td class="patch">? <a href="patch_stdout.txt">stdout</a> | <a href="patch_stderr.txt">stderr</a></td>
                 <td class="diff"></td>
             </tr>
             <tr>

--- a/test/resources/html_report_builder/patch/stderr.txt
+++ b/test/resources/html_report_builder/patch/stderr.txt
@@ -1,0 +1,1 @@
+patch stderr

--- a/test/resources/html_report_builder/patch/stdout.txt
+++ b/test/resources/html_report_builder/patch/stdout.txt
@@ -1,0 +1,1 @@
+patch stdout

--- a/test/resources/html_report_builder/patch_report_info.json
+++ b/test/resources/html_report_builder/patch_report_info.json
@@ -1,1 +1,1 @@
-{"execution_time":65,"timestamp":"patch time stamp","working_dir":"SHOULD_BE_REPLACED"}
+{"execution_time":65,"timestamp":"patch time stamp","working_dir":"SHOULD_BE_REPLACED","exit_code":"1"}

--- a/test/resources/project_diff_report/expected_full_base.html
+++ b/test/resources/project_diff_report/expected_full_base.html
@@ -54,6 +54,10 @@
                 <td class="base">base time stamp</td>
             </tr>
             <tr>
+                <td class="item">Exit Code</td>
+                <td class="base">0</td>
+            </tr>
+            <tr>
                 <td class="item">Full Report</td>
                 <td class="base"><a href="base_pmd_report.xml">base_pmd_report.xml</a></td>
             </tr>

--- a/test/resources/project_diff_report/expected_full_base.html
+++ b/test/resources/project_diff_report/expected_full_base.html
@@ -55,7 +55,7 @@
             </tr>
             <tr>
                 <td class="item">Exit Code</td>
-                <td class="base">0</td>
+                <td class="base">0 <a href="base_stdout.txt">stdout</a> | <a href="base_stderr.txt">stderr</a></td>
             </tr>
             <tr>
                 <td class="item">Full Report</td>

--- a/test/resources/project_diff_report/expected_full_patch.html
+++ b/test/resources/project_diff_report/expected_full_patch.html
@@ -54,6 +54,10 @@
                 <td class="patch">patch time stamp</td>
             </tr>
             <tr>
+                <td class="item">Exit Code</td>
+                <td class="patch">1</td>
+            </tr>
+            <tr>
                 <td class="item">Full Report</td>
                 <td class="patch"><a href="patch_pmd_report.xml">patch_pmd_report.xml</a></td>
             </tr>

--- a/test/resources/project_diff_report/expected_full_patch.html
+++ b/test/resources/project_diff_report/expected_full_patch.html
@@ -55,7 +55,7 @@
             </tr>
             <tr>
                 <td class="item">Exit Code</td>
-                <td class="patch">1</td>
+                <td class="patch">1 <a href="patch_stdout.txt">stdout</a> | <a href="patch_stderr.txt">stderr</a></td>
             </tr>
             <tr>
                 <td class="item">Full Report</td>

--- a/test/test_cmd.rb
+++ b/test/test_cmd.rb
@@ -11,7 +11,26 @@ class TestCmd < Test::Unit::TestCase
     assert_equal('Hello, World!', stdout)
   end
 
-  def test_invalid_cmd(cmd)
+  def test_invalid_cmd_1
+    cmd = 'cd DIR_NO_EXIST'
+    run_invalid_cmd(cmd)
+  end
+
+  def test_invalid_cmd_2
+    cmd = 'false'
+    run_invalid_cmd(cmd)
+  end
+
+  def test_failing_cmd
+    stdout, stderr, status = Cmd.execute('echo Hello; echo World >&2; exit 5')
+    assert_equal('Hello', stdout)
+    assert_equal('World', stderr)
+    assert_equal(5, status.exitstatus)
+  end
+
+  private
+
+  def run_invalid_cmd(cmd)
     expected_msg = "#{CmdException::COMMON_MSG} '#{cmd}'"
     begin
       Cmd.execute_successfully(cmd)
@@ -19,15 +38,5 @@ class TestCmd < Test::Unit::TestCase
       assert_equal(cmd, e.cmd)
       assert(e.message.start_with?(expected_msg))
     end
-  end
-
-  def test_invalid_cmd_1
-    cmd = 'cd DIR_NO_EXIST'
-    test_invalid_cmd(cmd)
-  end
-
-  def test_invalid_cmd_2
-    cmd = 'false'
-    test_invalid_cmd(cmd)
   end
 end

--- a/test/test_cmd.rb
+++ b/test/test_cmd.rb
@@ -7,17 +7,17 @@ class TestCmd < Test::Unit::TestCase
   include PmdTester
 
   def test_get_stdout
-    stdout = Cmd.execute('echo Hello, World!')
+    stdout = Cmd.execute_successfully('echo Hello, World!')
     assert_equal('Hello, World!', stdout)
   end
 
   def test_invalid_cmd(cmd)
     expected_msg = "#{CmdException::COMMON_MSG} '#{cmd}'"
     begin
-      Cmd.execute(cmd)
+      Cmd.execute_successfully(cmd)
     rescue CmdException => e
       assert_equal(cmd, e.cmd)
-      assert_equal(expected_msg, e.message)
+      assert(e.message.start_with?(expected_msg))
     end
   end
 

--- a/test/test_cmd.rb
+++ b/test/test_cmd.rb
@@ -6,6 +6,16 @@ require 'test_helper'
 class TestCmd < Test::Unit::TestCase
   include PmdTester
 
+  def setup
+    @tempdir = 'test-TestCmd-temp'
+    Dir.mkdir @tempdir unless Dir.exist?(@tempdir)
+  end
+
+  def teardown
+    Dir.each_child(@tempdir) { |x| File.unlink("#{@tempdir}/#{x}") }
+    Dir.rmdir(@tempdir)
+  end
+
   def test_get_stdout
     stdout = Cmd.execute_successfully('echo Hello, World!')
     assert_equal('Hello, World!', stdout)
@@ -22,9 +32,10 @@ class TestCmd < Test::Unit::TestCase
   end
 
   def test_failing_cmd
-    stdout, stderr, status = Cmd.execute('echo Hello; echo World >&2; exit 5')
-    assert_equal('Hello', stdout)
-    assert_equal('World', stderr)
+    status = Cmd.execute('echo Hello; echo World >&2; exit 5', @tempdir)
+
+    assert_equal("Hello\n", File.read("#{@tempdir}/stdout.txt"))
+    assert_equal("World\n", File.read("#{@tempdir}/stderr.txt"))
     assert_equal(5, status.exitstatus)
   end
 

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -52,9 +52,9 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     FileUtils.touch "target/repositories/pmd/pmd-dist/target/pmd-bin-#{@pmd_version}.zip"
 
     record_expectations('sha1abc', 'sha1abc', false)
-    PmdTester::Cmd.stubs(:execute).with("unzip -qo pmd-dist/target/pmd-bin-#{@pmd_version}.zip" \
+    PmdTester::Cmd.stubs(:execute_successfully).with("unzip -qo pmd-dist/target/pmd-bin-#{@pmd_version}.zip" \
       ' -d pmd-dist/target/exploded').once
-    PmdTester::Cmd.stubs(:execute).with("mv pmd-dist/target/exploded/pmd-bin-#{@pmd_version}" \
+    PmdTester::Cmd.stubs(:execute_successfully).with("mv pmd-dist/target/exploded/pmd-bin-#{@pmd_version}" \
       " #{Dir.getwd}/target/pmd-bin-#{@pmd_version}-master-sha1abc").once
     record_expectations_after_build
 
@@ -71,12 +71,12 @@ class TestPmdReportBuilder < Test::Unit::TestCase
 
     # PMD binary does not exist yet this time...
     record_expectations('sha1abc', 'sha1abc', false)
-    PmdTester::Cmd.stubs(:execute).with('./mvnw clean package -Dmaven.test.skip=true' \
+    PmdTester::Cmd.stubs(:execute_successfully).with('./mvnw clean package -Dmaven.test.skip=true' \
                   ' -Dmaven.javadoc.skip=true -Dmaven.source.skip=true' \
                   ' -Dcheckstyle.skip=true -Dpmd.skip=true -T1C -B').once
-    PmdTester::Cmd.stubs(:execute).with("unzip -qo pmd-dist/target/pmd-bin-#{@pmd_version}.zip" \
+    PmdTester::Cmd.stubs(:execute_successfully).with("unzip -qo pmd-dist/target/pmd-bin-#{@pmd_version}.zip" \
                   ' -d pmd-dist/target/exploded').once
-    PmdTester::Cmd.stubs(:execute).with("mv pmd-dist/target/exploded/pmd-bin-#{@pmd_version}" \
+    PmdTester::Cmd.stubs(:execute_successfully).with("mv pmd-dist/target/exploded/pmd-bin-#{@pmd_version}" \
                   " #{Dir.getwd}/target/pmd-bin-#{@pmd_version}-master-sha1abc").once
     record_expectations_after_build
 
@@ -169,18 +169,18 @@ class TestPmdReportBuilder < Test::Unit::TestCase
   end
 
   def record_expectations(sha1_head, sha1_base, zip_file_exists)
-    PmdTester::Cmd.stubs(:execute).with('git rev-parse master^{commit}').returns(sha1_base).once
+    PmdTester::Cmd.stubs(:execute_successfully).with('git rev-parse master^{commit}').returns(sha1_base).once
     # inside checkout_build_branch
-    PmdTester::Cmd.stubs(:execute).with('git checkout master')
+    PmdTester::Cmd.stubs(:execute_successfully).with('git checkout master')
                   .returns('checked out branch master').once
-    PmdTester::Cmd.stubs(:execute).with('./mvnw -q -Dexec.executable="echo" ' \
+    PmdTester::Cmd.stubs(:execute_successfully).with('./mvnw -q -Dexec.executable="echo" ' \
                   "-Dexec.args='${project.version}' " \
                   '--non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec')
                   .returns(@pmd_version).at_least(1).at_most(2)
-    PmdTester::Cmd.stubs(:execute).with('git status --porcelain').returns('').once
+    PmdTester::Cmd.stubs(:execute_successfully).with('git status --porcelain').returns('').once
 
     # back into get_pmd_binary_file
-    PmdTester::Cmd.stubs(:execute).with('git rev-parse HEAD^{commit}').returns(sha1_head).once
+    PmdTester::Cmd.stubs(:execute_successfully).with('git rev-parse HEAD^{commit}').returns(sha1_head).once
     # PMD binary might not exist yet...
     distro_path = "target/pmd-bin-#{@pmd_version}-master-#{sha1_base}"
     if zip_file_exists
@@ -191,7 +191,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
   end
 
   def record_expectations_after_build
-    PmdTester::Cmd.stubs(:execute).with('git log -1 --pretty=%B').returns('the commit message').once
+    PmdTester::Cmd.stubs(:execute_successfully).with('git log -1 --pretty=%B').returns('the commit message').once
     PmdTester::PmdBranchDetail.any_instance.stubs(:save).once
     FileUtils.stubs(:cp).with('config/design.xml', 'target/reports/master/config.xml').once
   end

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -147,9 +147,32 @@ class TestPmdReportBuilder < Test::Unit::TestCase
       .build
   end
 
+  #
+  # Continue even if PMD exits with a unsuccessful exit code
+  # Verify that stdout/stderr files are created
+  #
+  def test_build_failing
+    project_list = 'test/resources/pmd_report_builder/project-list.xml'
+    projects = PmdTester::ProjectsParser.new.parse(project_list)
+    assert_equal(1, projects.size)
+    argv = %w[-r target/repositories/pmd -b master -p pmd_releases/6.1.0
+              -c config/design.xml --debug --error-recovery -l]
+    argv.push project_list
+    options = PmdTester::Options.new(argv)
+
+    projects[0].auxclasspath = '-auxclasspath extra:dirs'
+    record_expectations('sha1abc', 'sha1abc', true)
+    record_expectations_after_build
+    record_expectations_project_build('sha1abc', true, false, 1)
+
+    PmdTester::PmdReportBuilder
+      .new(projects, options, options.base_config, options.base_branch)
+      .build
+  end
+
   private
 
-  def record_expectations_project_build(sha1, error = false, long_cli_options = false)
+  def record_expectations_project_build(sha1, error = false, long_cli_options = false, exit_status = 0)
     PmdTester::ProjectBuilder.any_instance.stubs(:clone_projects).once
     PmdTester::ProjectBuilder.any_instance.stubs(:build_projects).once
     PmdTester::SimpleProgressLogger.any_instance.stubs(:start).once
@@ -157,6 +180,8 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     error_prefix = error ? 'PMD_JAVA_OPTS="-Dpmd.error_recovery -ea" ' : ''
     distro_path = "#{Dir.getwd}/target/pmd-bin-#{@pmd_version}-master-#{sha1}"
     fail_on_violation = long_cli_options ? '--fail-on-violation false' : '-failOnViolation false'
+    process_status = mock
+    process_status.expects(:exitstatus).returns(exit_status).once
     PmdTester::Cmd.stubs(:execute)
                   .with("#{error_prefix}" \
                         "#{distro_path}/bin/run.sh " \
@@ -164,8 +189,10 @@ class TestPmdReportBuilder < Test::Unit::TestCase
                         '-R target/reports/master/checkstyle/config.xml ' \
                         '-r target/reports/master/checkstyle/pmd_report.xml ' \
                         "#{fail_on_violation} -t 1 " \
-                        '-auxclasspath extra:dirs').once
-    PmdTester::PmdReportDetail.any_instance.stubs(:save).once
+                        '-auxclasspath extra:dirs')
+                  .returns(['test stdout', 'test stderr', process_status])
+                  .once
+    PmdTester::PmdReportDetail.stubs(:create).once.with { |params| params[:exit_code] == exit_status }
   end
 
   def record_expectations(sha1_head, sha1_base, zip_file_exists)

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -189,8 +189,9 @@ class TestPmdReportBuilder < Test::Unit::TestCase
                         '-R target/reports/master/checkstyle/config.xml ' \
                         '-r target/reports/master/checkstyle/pmd_report.xml ' \
                         "#{fail_on_violation} -t 1 " \
-                        '-auxclasspath extra:dirs')
-                  .returns(['test stdout', 'test stderr', process_status])
+                        '-auxclasspath extra:dirs',
+                        'target/reports/master/checkstyle')
+                  .returns(process_status)
                   .once
     PmdTester::PmdReportDetail.stubs(:create).once.with { |params| params[:exit_code] == exit_status }
   end

--- a/test/test_pmd_report_detail.rb
+++ b/test/test_pmd_report_detail.rb
@@ -10,7 +10,7 @@ class TestPmdReportDetail < Test::Unit::TestCase
     FileUtils.mkdir(dir) unless File.directory?(dir)
     report_path = "#{dir}/report_info.json"
 
-    details = PmdReportDetail.new(execution_time: 121, timestamp: 'timestamp')
+    details = PmdReportDetail.new(execution_time: 121, timestamp: 'timestamp', exit_code: 0)
     details.save(report_path)
 
     details = PmdReportDetail.load(report_path)
@@ -19,5 +19,18 @@ class TestPmdReportDetail < Test::Unit::TestCase
     assert_equal('timestamp', details.timestamp)
     assert_equal('00:02:01', details.format_execution_time)
     assert_equal(Dir.getwd, details.working_dir)
+    assert_equal('0', details.exit_code)
+  end
+
+  def test_create
+    dir = 'target/reports/test_branch'
+    FileUtils.mkdir(dir) unless File.directory?(dir)
+    report_path = "#{dir}/report_info.json"
+
+    details = PmdReportDetail.create(execution_time: 5, timestamp: 'ts', exit_code: 1, report_info_path: report_path)
+    assert_equal('1', details.exit_code)
+
+    details2 = PmdReportDetail.load(report_path)
+    assert_equal(details.exit_code, details2.exit_code)
   end
 end

--- a/test/test_project_builder.rb
+++ b/test/test_project_builder.rb
@@ -38,10 +38,10 @@ class TestProjectBuilder < Test::Unit::TestCase
 
   def expect_git_clone(name, url, revision)
     File.stubs(:exist?).with("target/repositories/#{name}").returns(false).once
-    PmdTester::Cmd.stubs(:execute).with('git clone --no-single-branch --depth 1' \
+    PmdTester::Cmd.stubs(:execute_successfully).with('git clone --no-single-branch --depth 1' \
                                         " #{url} target/repositories/#{name}").once
     Dir.stubs(:chdir).with("target/repositories/#{name}").yields.once
-    PmdTester::Cmd.stubs(:execute).with("git checkout #{revision}; git reset --hard #{revision}").once
+    PmdTester::Cmd.stubs(:execute_successfully).with("git checkout #{revision}; git reset --hard #{revision}").once
   end
 
   def expect_build(name, build_cmd = nil, auxclasspath_cmd = nil)
@@ -62,7 +62,7 @@ class TestProjectBuilder < Test::Unit::TestCase
     build_cmd_mock.stubs(:write).with(build_cmd).once
     build_cmd_mock.stubs(:close).once
     build_cmd_mock.stubs(:unlink).once
-    PmdTester::Cmd.stubs(:execute)
+    PmdTester::Cmd.stubs(:execute_successfully)
                   .with(regexp_matches(/sh -xe build-cmd-script/)).once
   end
 
@@ -71,7 +71,7 @@ class TestProjectBuilder < Test::Unit::TestCase
     auxclasspath_cmd_mock.stubs(:write).with(auxclasspath_cmd).once
     auxclasspath_cmd_mock.stubs(:close).once
     auxclasspath_cmd_mock.stubs(:unlink).once
-    PmdTester::Cmd.stubs(:execute)
+    PmdTester::Cmd.stubs(:execute_successfully)
                   .with(regexp_matches(%r{/usr/bin/env bash auxclasspath-cmd-script}))
                   .returns('the-aux').once
   end

--- a/test/test_project_diff_report.rb
+++ b/test/test_project_diff_report.rb
@@ -6,6 +6,10 @@ require 'test_helper'
 class TestProjectDiffReport < Test::Unit::TestCase
   include PmdTester::PmdTesterUtils
   include TestUtils
+
+  BASE_REPORT_FOLDER = 'test/resources/html_report_builder/base'
+  PATCH_REPORT_FOLDER = 'test/resources/html_report_builder/patch'
+
   BASE_PMD_REPORT_PATH =
     'test/resources/html_report_builder/test_html_report_builder_base.xml'
   PATCH_PMD_REPORT_PATH =
@@ -33,6 +37,8 @@ class TestProjectDiffReport < Test::Unit::TestCase
 
     project.report_diff = build_report_diff(BASE_PMD_REPORT_PATH, PATCH_PMD_REPORT_PATH,
                                             BASE_REPORT_INFO_PATH, PATCH_REPORT_INFO_PATH)
+    project.report_diff.base_report.report_folder = BASE_REPORT_FOLDER
+    project.report_diff.patch_report.report_folder = PATCH_REPORT_FOLDER
 
     PmdTester::LiquidProjectRenderer.new.write_project_index(project, actual_report_path)
 
@@ -42,10 +48,14 @@ class TestProjectDiffReport < Test::Unit::TestCase
     assert_file_exists("#{actual_report_path}/base_pmd_report.xml")
     assert_file_exists("#{actual_report_path}/base_data.js")
     assert_file_exists("#{actual_report_path}/base_pmd_report.html")
+    assert_file_exists("#{actual_report_path}/base_stdout.txt")
+    assert_file_exists("#{actual_report_path}/base_stderr.txt")
     assert_file_equals(EXPECTED_FULL_BASE_HTML_REPORT, "#{actual_report_path}/base_pmd_report.html")
     assert_file_exists("#{actual_report_path}/patch_pmd_report.xml")
     assert_file_exists("#{actual_report_path}/patch_data.js")
     assert_file_exists("#{actual_report_path}/patch_pmd_report.html")
+    assert_file_exists("#{actual_report_path}/patch_stdout.txt")
+    assert_file_exists("#{actual_report_path}/patch_stderr.txt")
     assert_file_equals(EXPECTED_FULL_PATCH_HTML_REPORT, "#{actual_report_path}/patch_pmd_report.html")
   end
 

--- a/test/test_rule_set_builder.rb
+++ b/test/test_rule_set_builder.rb
@@ -28,7 +28,7 @@ class TestRuleSetBuilder < Test::Unit::TestCase
     end
     options.expects(:mode).returns('local').at_most_once
     builder = RuleSetBuilder.new(options)
-    Cmd.expects(:execute).returns(diff_filenames)
+    Cmd.expects(:execute_successfully).returns(diff_filenames)
     builder.build?
   end
 

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -104,8 +104,8 @@ class TestRunner < Test::Unit::TestCase
     File.stubs(:new).with('target/reports/diff/index.html', anything).returns.once
 
     Dir.stubs(:chdir).with('target/reports').yields.once
-    Cmd.stubs(:execute).with('wget --timestamping https://sourceforge.net/projects/pmd/files/pmd-regression-tester/master-baseline.zip').once
-    Cmd.stubs(:execute).with('unzip -qo master-baseline.zip').once
+    Cmd.stubs(:execute_successfully).with('wget --timestamping https://sourceforge.net/projects/pmd/files/pmd-regression-tester/master-baseline.zip').once
+    Cmd.stubs(:execute_successfully).with('unzip -qo master-baseline.zip').once
     ProjectsParser.any_instance.stubs(:parse)
                   .with('target/reports/master/project-list.xml')
                   .returns([]).once
@@ -120,7 +120,7 @@ class TestRunner < Test::Unit::TestCase
   def test_online_mode_multithreading
     FileUtils.stubs(:mkdir_p).with('target/reports').at_most_once
     Dir.stubs(:chdir).with('target/reports').yields.once
-    Cmd.stubs(:execute).twice
+    Cmd.stubs(:execute_successfully).twice
     ProjectsParser.any_instance.stubs(:parse)
                   .with('target/reports/master/project-list.xml')
                   .returns([]).once

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -4,6 +4,8 @@ require 'test_helper'
 
 # Unit test class for PmdTester::Runner
 class TestRunner < Test::Unit::TestCase
+  include PmdTester
+
   def setup
     `rake clean`
 
@@ -11,8 +13,6 @@ class TestRunner < Test::Unit::TestCase
     clone_cmd = "git clone --no-single-branch --depth 1 https://github.com/pmd/pmd #{pmd_repo_path}"
     `#{clone_cmd}` unless Dir.exist?(pmd_repo_path)
   end
-
-  include PmdTester
 
   def run_runner(argv)
     runner = Runner.new(argv)
@@ -25,7 +25,7 @@ class TestRunner < Test::Unit::TestCase
     PmdReportBuilder.any_instance.stubs(:build)
                     .returns(PmdBranchDetail.new('test_branch')).once
     FileUtils.expects(:cp).with(project_list_path, target_project_list_path).once
-    Project.any_instance.stubs(:build_report_diff).twice
+    Project.any_instance.stubs(:compute_report_diff).twice
     SummaryReportBuilder.any_instance.stubs(:write_all_projects).once
 
     argv = %w[-r target/repositories/pmd -p pmd_releases/6.1.0
@@ -58,7 +58,7 @@ class TestRunner < Test::Unit::TestCase
                     .once
     report_builder_mock.stubs(:build).returns(PmdBranchDetail.new('test_branch')).once
     FileUtils.expects(:cp).with(anything, anything).once
-    Project.any_instance.stubs(:build_report_diff).twice
+    Project.any_instance.stubs(:compute_report_diff).twice
     SummaryReportBuilder.any_instance.stubs(:write_all_projects).once
 
     argv = %w[-r target/repositories/pmd -p pmd_releases/6.1.0
@@ -69,7 +69,7 @@ class TestRunner < Test::Unit::TestCase
 
   def test_local_mode
     PmdReportBuilder.any_instance.stubs(:build).returns(PmdBranchDetail.new('some_branch')).twice
-    Project.any_instance.stubs(:build_report_diff).twice
+    Project.any_instance.stubs(:compute_report_diff).twice
     SummaryReportBuilder.any_instance.stubs(:write_all_projects).once
 
     argv = %w[-r target/repositories/pmd -b master -bc config/design.xml -p pmd_releases/6.1.0
@@ -87,7 +87,7 @@ class TestRunner < Test::Unit::TestCase
                     .returns(report_builder_mock)
                     .twice
     report_builder_mock.stubs(:build).returns(PmdBranchDetail.new('some_branch')).twice
-    Project.any_instance.stubs(:build_report_diff).twice
+    Project.any_instance.stubs(:compute_report_diff).twice
     SummaryReportBuilder.any_instance.stubs(:write_all_projects).once
 
     argv = %w[-r target/repositories/pmd -b master -bc config/design.xml -p pmd_releases/6.1.0


### PR DESCRIPTION
Fixes #109 

Note: this doesn't include diffing stdout/stderr of base against patch. This could be done later if needed.