### PR TITLE
Support new PMD 7 CLI interface

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Metrics/BlockLength:
 
 Metrics/ModuleLength:
   CountAsOne: ['array', 'hash']
+
+Metrics/ParameterLists:
+  CountKeywordArgs: false

--- a/History.md
+++ b/History.md
@@ -4,6 +4,8 @@
 
 ## Enhancements
 
+* [#114](https://github.com/pmd/pmd-regression-tester/pull/114): Support new PMD 7 CLI interface
+
 ## Fixed Issues
 
 ## External Contributions

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -221,7 +221,7 @@ module PmdTester
       run_path = "#{saved_distro_path(@pmd_branch_details.branch_last_sha)}/bin"
       run_path = if File.exist?("#{run_path}/pmd")
                    # New PMD 7 CLI script (pmd/pmd#4059)
-                   "#{run_path}/pmd analyze"
+                   "#{run_path}/pmd check"
                  else
                    "#{run_path}/run.sh pmd"
                  end

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -96,11 +96,11 @@ module PmdTester
 
     def generate_pmd_report(project)
       error_recovery_options = @error_recovery ? 'PMD_JAVA_OPTS="-Dpmd.error_recovery -ea" ' : ''
-      run_path = "#{saved_distro_path(@pmd_branch_details.branch_last_sha)}/bin/run.sh"
-      fail_on_violation = should_use_long_cli_options ? '--fail-on-violation false' : '-failOnViolation false'
+      run_path = "#{saved_distro_path(@pmd_branch_details.branch_last_sha)}/bin/#{pmd7? ? 'pmd analyze' : 'run.sh pmd'}"
+      fail_on_violation = should_use_long_cli_options? ? '--fail-on-violation false' : '-failOnViolation false'
       auxclasspath_option = create_auxclasspath_option(project)
       pmd_cmd = "#{error_recovery_options}" \
-                "#{run_path} pmd -d #{project.local_source_path} -f xml " \
+                "#{run_path} -d #{project.local_source_path} -f xml " \
                 "-R #{project.get_config_path(@pmd_branch_name)} " \
                 "-r #{project.get_pmd_report_path(@pmd_branch_name)} " \
                 "#{fail_on_violation} -t #{@threads} " \
@@ -149,7 +149,7 @@ module PmdTester
 
         PmdReportDetail.create(execution_time: execution_time, timestamp: end_time,
                                exit_code: exit_code, report_info_path: project.get_report_info_path(@pmd_branch_name))
-        logger.info "#{project.name}'s PMD report was generated successfully"
+        logger.info "#{project.name}'s PMD report was generated successfully (exit code: #{exit_code})"
       end
 
       @pmd_branch_details.execution_time = sum_time
@@ -200,7 +200,7 @@ module PmdTester
       !Cmd.execute_successfully('git status --porcelain').empty?
     end
 
-    def should_use_long_cli_options
+    def should_use_long_cli_options?
       logger.debug "PMD Version: #{@pmd_version}"
       Semver.compare(@pmd_version, '6.41.0') >= 0
     end
@@ -208,7 +208,7 @@ module PmdTester
     def create_auxclasspath_option(project)
       auxclasspath_option = ''
       unless project.auxclasspath.empty?
-        auxclasspath_option = should_use_long_cli_options ? '--aux-classpath ' : '-auxclasspath '
+        auxclasspath_option = should_use_long_cli_options? ? '--aux-classpath ' : '-auxclasspath '
         auxclasspath_option += project.auxclasspath
       end
       auxclasspath_option

--- a/lib/pmdtester/pmd_violation.rb
+++ b/lib/pmdtester/pmd_violation.rb
@@ -30,8 +30,6 @@ module PmdTester
     attr_reader :fname, :info_url, :line, :old_line, :old_message, :rule_name, :ruleset_name, :language
     attr_accessor :message
 
-    # rubocop:disable Metrics/ParameterLists
-    # Disable it: how is replacing a long parameter list with a single hash helping?
     def initialize(branch:, fname:, info_url:, bline:, rule_name:, ruleset_name:)
       @branch = branch
       @fname = fname
@@ -49,7 +47,6 @@ module PmdTester
       @old_message = nil
       @old_line = nil
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def line_move?(other)
       message.eql?(other.message) && (line - other.line).abs <= 5

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/pmd/pmd-regression-tester/issues", "homepage_uri" => "https://pmd.github.io", "source_code_uri" => "https://github.com/pmd/pmd-regression-tester" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze, "Cl\u00E9ment Fournier".freeze]
-  s.date = "2022-10-13"
+  s.date = "2022-10-16"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@pmd-code.org".freeze, "djydewang@gmail.com".freeze, "clement.fournier76@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/pmd/pmd-regression-tester/issues", "homepage_uri" => "https://pmd.github.io", "source_code_uri" => "https://github.com/pmd/pmd-regression-tester" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze, "Cl\u00E9ment Fournier".freeze]
-  s.date = "2022-05-12"
+  s.date = "2022-10-07"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@pmd-code.org".freeze, "djydewang@gmail.com".freeze, "clement.fournier76@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency(%q<rubocop>.freeze, ["~> 0.93"])
     s.add_development_dependency(%q<test-unit>.freeze, ["~> 3.5"])
     s.add_development_dependency(%q<rdoc>.freeze, ["~> 6.4"])
-    s.add_development_dependency(%q<hoe>.freeze, ["~> 3.23"])
+    s.add_development_dependency(%q<hoe>.freeze, ["~> 3.25"])
   else
     s.add_dependency(%q<nokogiri>.freeze, ["~> 1.13"])
     s.add_dependency(%q<slop>.freeze, ["~> 4.6"])
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rubocop>.freeze, ["~> 0.93"])
     s.add_dependency(%q<test-unit>.freeze, ["~> 3.5"])
     s.add_dependency(%q<rdoc>.freeze, ["~> 6.4"])
-    s.add_dependency(%q<hoe>.freeze, ["~> 3.23"])
+    s.add_dependency(%q<hoe>.freeze, ["~> 3.25"])
   end
 end
 

--- a/pmdtester.gemspec
+++ b/pmdtester.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = { "bug_tracker_uri" => "https://github.com/pmd/pmd-regression-tester/issues", "homepage_uri" => "https://pmd.github.io", "source_code_uri" => "https://github.com/pmd/pmd-regression-tester" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Andreas Dangel".freeze, "Binguo Bao".freeze, "Cl\u00E9ment Fournier".freeze]
-  s.date = "2022-10-07"
+  s.date = "2022-10-13"
   s.description = "A regression testing tool ensure that new problems and unexpected behaviors will not be introduced to PMD project after fixing an issue , and new rules can work as expected.".freeze
   s.email = ["andreas.dangel@pmd-code.org".freeze, "djydewang@gmail.com".freeze, "clement.fournier76@gmail.com".freeze]
   s.executables = ["pmdtester".freeze]

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -162,7 +162,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     record_expectations(sha1, sha1, true)
     record_expectations_after_build
     record_expectations_project_build(sha1: sha1, error: true, long_cli_options: true,
-                                      no_progress_bar: true, base_cmd: 'pmd analyze')
+                                      no_progress_bar: true, base_cmd: 'pmd check')
 
     pmd_cli_cmd = prepare_pmd_dist_dir(version: @pmd_version, sha1: sha1)
     begin

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -149,6 +149,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
 
   def test_build_pmd7
     @pmd_version = '7.0.0-SNAPSHOT'
+    sha1 = 'sha1abc'
     project_list = 'test/resources/pmd_report_builder/project-list.xml'
     projects = PmdTester::ProjectsParser.new.parse(project_list)
     assert_equal(1, projects.size)
@@ -158,14 +159,19 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     options = PmdTester::Options.new(argv)
 
     projects[0].auxclasspath = 'extra:dirs'
-    record_expectations('sha1abc', 'sha1abc', true)
+    record_expectations(sha1, sha1, true)
     record_expectations_after_build
-    record_expectations_project_build(sha1: 'sha1abc', error: true, long_cli_options: true,
+    record_expectations_project_build(sha1: sha1, error: true, long_cli_options: true,
                                       no_progress_bar: true, base_cmd: 'pmd analyze')
 
-    PmdTester::PmdReportBuilder
-      .new(projects, options, options.base_config, options.base_branch)
-      .build
+    pmd_cli_cmd = prepare_pmd_dist_dir(version: @pmd_version, sha1: sha1)
+    begin
+      PmdTester::PmdReportBuilder
+        .new(projects, options, options.base_config, options.base_branch)
+        .build
+    ensure
+      cleanup_pmd_dist_dir(base_dir: pmd_cli_cmd)
+    end
   end
 
   #
@@ -244,5 +250,19 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     PmdTester::Cmd.stubs(:execute_successfully).with('git log -1 --pretty=%B').returns('the commit message').once
     PmdTester::PmdBranchDetail.any_instance.stubs(:save).once
     FileUtils.stubs(:cp).with('config/design.xml', 'target/reports/master/config.xml').once
+  end
+
+  # Creates a fake pmd script file as .../bin/pmd.
+  # This is used in the new PMD 7 CLI interface
+  def prepare_pmd_dist_dir(version:, sha1:)
+    pmd_cli_cmd = "#{Dir.getwd}/target/pmd-bin-#{version}-master-#{sha1}/bin"
+    FileUtils.mkdir_p(pmd_cli_cmd)
+    File.new("#{pmd_cli_cmd}/pmd", 'w')
+    pmd_cli_cmd
+  end
+
+  def cleanup_pmd_dist_dir(base_dir:)
+    File.unlink("#{base_dir}/pmd")
+    Dir.rmdir(base_dir)
   end
 end

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -97,7 +97,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     projects[0].auxclasspath = 'extra:dirs'
     record_expectations('sha1abc', 'sha1abc', true)
     record_expectations_after_build
-    record_expectations_project_build('sha1abc')
+    record_expectations_project_build(sha1: 'sha1abc')
 
     PmdTester::PmdReportBuilder
       .new(projects, options, options.base_config, options.base_branch)
@@ -120,7 +120,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     projects[0].auxclasspath = 'extra:dirs'
     record_expectations('sha1abc', 'sha1abc', true)
     record_expectations_after_build
-    record_expectations_project_build('sha1abc', true)
+    record_expectations_project_build(sha1: 'sha1abc', error: true)
 
     PmdTester::PmdReportBuilder
       .new(projects, options, options.base_config, options.base_branch)
@@ -140,7 +140,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     projects[0].auxclasspath = 'extra:dirs'
     record_expectations('sha1abc', 'sha1abc', true)
     record_expectations_after_build
-    record_expectations_project_build('sha1abc', true, true)
+    record_expectations_project_build(sha1: 'sha1abc', error: true, long_cli_options: true)
 
     PmdTester::PmdReportBuilder
       .new(projects, options, options.base_config, options.base_branch)
@@ -160,7 +160,8 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     projects[0].auxclasspath = 'extra:dirs'
     record_expectations('sha1abc', 'sha1abc', true)
     record_expectations_after_build
-    record_expectations_project_build('sha1abc', true, true, true)
+    record_expectations_project_build(sha1: 'sha1abc', error: true, long_cli_options: true,
+                                      no_progress_bar: true, base_cmd: 'pmd analyze')
 
     PmdTester::PmdReportBuilder
       .new(projects, options, options.base_config, options.base_branch)
@@ -183,7 +184,7 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     projects[0].auxclasspath = 'extra:dirs'
     record_expectations('sha1abc', 'sha1abc', true)
     record_expectations_after_build
-    record_expectations_project_build('sha1abc', true, false, false, 1)
+    record_expectations_project_build(sha1: 'sha1abc', error: true, exit_status: 1)
 
     PmdTester::PmdReportBuilder
       .new(projects, options, options.base_config, options.base_branch)
@@ -192,8 +193,8 @@ class TestPmdReportBuilder < Test::Unit::TestCase
 
   private
 
-  def record_expectations_project_build(sha1, error = false, long_cli_options = false,
-                                        no_progress_bar = false, exit_status = 0)
+  def record_expectations_project_build(sha1:, error: false, long_cli_options: false,
+                                        no_progress_bar: false, exit_status: 0, base_cmd: 'run.sh pmd')
     PmdTester::ProjectBuilder.any_instance.stubs(:clone_projects).once
     PmdTester::ProjectBuilder.any_instance.stubs(:build_projects).once
     PmdTester::SimpleProgressLogger.any_instance.stubs(:start).once
@@ -204,8 +205,8 @@ class TestPmdReportBuilder < Test::Unit::TestCase
     process_status.expects(:exitstatus).returns(exit_status).once
     PmdTester::Cmd.stubs(:execute)
                   .with("#{error_prefix}" \
-                        "#{distro_path}/bin/run.sh " \
-                        'pmd -d target/repositories/checkstyle -f xml ' \
+                        "#{distro_path}/bin/#{base_cmd} " \
+                        '-d target/repositories/checkstyle -f xml ' \
                         '-R target/reports/master/checkstyle/config.xml ' \
                         '-r target/reports/master/checkstyle/pmd_report.xml ' \
                         "#{long_cli_options ? '--fail-on-violation false' : '-failOnViolation false'} -t 1 " \


### PR DESCRIPTION
* Refs pmd/pmd#4059

This adds support for thew new PicoCLI based command line. The actual parameters didn't change, but the base command:

- PMD 6: `bin/run.sh pmd`
- PMD 7: `bin/pmd check`


