### PR TITLE
Fix integration tests

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -56,6 +56,7 @@ resources/js/datatables.min.js
 resources/js/jquery-3.6.4.slim.min.js
 resources/js/popper-2.11.7.min.js
 resources/js/project-report.js
+resources/maven-settings.xml
 resources/project_diff_report.html
 resources/project_index.html
 resources/project_pmd_report.html

--- a/README.rdoc
+++ b/README.rdoc
@@ -136,8 +136,15 @@ The tool creates the following folders:
   bundle exec rake verify # run this command before commit your changes
   bundle exec pmdtester ... # run this to directly execute pmdtester from source
   
+  Run all unit tests:
+  bundle exec rake clean test
+
+  Run all integration tests:
+  bundle exec rake clean integration-test
+
   Run a single test class, e.g.:
   bundle exec ruby -I test test/test_project_diff_report.rb
+  bundle exec ruby -I test test/integration_test_runner.rb
   
   Run a single test, e.g.:
   bundle exec ruby -I test test/test_project_diff_report.rb -n test_diff_report_builder

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -248,6 +248,8 @@ module PmdTester
     def build_pmd_with_maven
       logger.info "#{@pmd_branch_name}: Building PMD #{@pmd_version}..."
       package_cmd = './mvnw clean package' \
+                    " -s #{ResourceLocator.resource('maven-settings.xml')} " \
+                    ' -Pfor-dokka-maven-plugin' \
                     ' -Dmaven.test.skip=true' \
                     ' -Dmaven.javadoc.skip=true' \
                     ' -Dmaven.source.skip=true' \

--- a/resources/maven-settings.xml
+++ b/resources/maven-settings.xml
@@ -1,0 +1,25 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>for-dokka-maven-plugin</id>
+      <pluginRepositories>
+        <pluginRepository>
+            <!-- needed for dokka-maven-plugin in pmd-lang-test -->
+            <id>kotlinx-html</id>
+            <name>KotlinxHTML Repository</name>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <url>https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven/</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/test/test_pmd_report_builder.rb
+++ b/test/test_pmd_report_builder.rb
@@ -324,7 +324,10 @@ class TestPmdReportBuilder < Test::Unit::TestCase
 
   def stub_pmd_build_maven(binary_name:)
     PmdTester::Cmd.stubs(:execute_successfully).with do |cmd|
-      if cmd == './mvnw clean package -Dmaven.test.skip=true' \
+      if cmd == './mvnw clean package ' \
+                  "-s #{PmdTester::ResourceLocator.resource('maven-settings.xml')} " \
+                  ' -Pfor-dokka-maven-plugin' \
+                  ' -Dmaven.test.skip=true' \
                   ' -Dmaven.javadoc.skip=true -Dmaven.source.skip=true' \
                   ' -Dcheckstyle.skip=true -Dpmd.skip=true -T1C -B'
         FileUtils.mkdir_p 'pmd-dist/target'


### PR DESCRIPTION
Add a maven-settings.xml for building (old) PMD versions with another maven repository, since dokka-maven-plugins uses a dependency (kotlinx-html-jvm) which was once available via jcenter.bintray.com, but bintray.com no longer exists today.