### PR TITLE
Fix integration tests - missing pmd-core:jar:tests

### DIFF
--- a/History.md
+++ b/History.md
@@ -24,6 +24,7 @@ projects. You might need to add `<tag>master</tag>` for some projects.
 * [#131](https://github.com/pmd/pmd-regression-tester/pull/131): Refactor GitHub Actions Workflows
 * [#132](https://github.com/pmd/pmd-regression-tester/pull/132): Fix manual integration test - Update expected_patch_config_3.xml: no more plsql exclusion
 * [#133](https://github.com/pmd/pmd-regression-tester/pull/133): \[ci] Make build a reuseable workflow
+* [#136](https://github.com/pmd/pmd-regression-tester/pull/136): Fix integration tests - missing pmd-core:jar:tests
 
 ## External Contributions
 

--- a/lib/pmdtester/builders/pmd_report_builder.rb
+++ b/lib/pmdtester/builders/pmd_report_builder.rb
@@ -250,15 +250,26 @@ module PmdTester
 
     def build_pmd_with_maven
       logger.info "#{@pmd_branch_name}: Building PMD #{@pmd_version}..."
-      package_cmd = './mvnw clean package ' \
-                    "-s #{ResourceLocator.resource('maven-settings.xml')} " \
-                    '-Pfor-dokka-maven-plugin ' \
-                    '-Dmaven.test.skip=true ' \
-                    '-Dmaven.javadoc.skip=true ' \
-                    '-Dmaven.source.skip=true ' \
-                    '-Dcheckstyle.skip=true ' \
-                    '-Dpmd.skip=true ' \
-                    '-T1C -B'
+
+      if Semver.compare(@pmd_version, '7.14.0') >= 0
+        # build command since PMD migrated to central portal
+        package_cmd = './mvnw clean package ' \
+                      '-PfastSkip ' \
+                      '-DskipTests ' \
+                      '-T1C -B'
+      else
+        # build command for older PMD versions
+        package_cmd = './mvnw clean package ' \
+                      "-s #{ResourceLocator.resource('maven-settings.xml')} " \
+                      '-Pfor-dokka-maven-plugin ' \
+                      '-Dmaven.test.skip=true ' \
+                      '-Dmaven.javadoc.skip=true ' \
+                      '-Dmaven.source.skip=true ' \
+                      '-Dcheckstyle.skip=true ' \
+                      '-Dpmd.skip=true ' \
+                      '-T1C -B'
+      end
+
       logger.debug "#{@pmd_branch_name}: maven command: #{package_cmd}"
       Cmd.execute_successfully(package_cmd)
     end


### PR DESCRIPTION
With the change to central portal, the snapshot repositories have been removed. Apparently the build was not independent and required e.g. pmd-core:jar:tests, which was not built due to maven.test.skip=true.

Simplifying this now for PMD >= 7.14.0 by using profile "fastSkip".