### PR TITLE
Fix #124: If an abstract rule is changed, run all rules

### DIFF
--- a/lib/pmdtester/builders/rule_set_builder.rb
+++ b/lib/pmdtester/builders/rule_set_builder.rb
@@ -146,7 +146,7 @@ module PmdTester
 
       # matches Java-based rule implementations
       match_data = %r{.+/src/main/java/.+/lang/([^/]+)/rule/([^/]+)/([^/]+)Rule.java}.match(filename)
-      unless match_data.nil?
+      unless match_data.nil? || match_data[3].start_with?('Abstract')
         logger.debug "Matches: #{match_data.inspect}"
         rules.add("#{match_data[1]}/#{match_data[2]}.xml/#{match_data[3]}")
         return true

--- a/test/test_rule_set_builder.rb
+++ b/test/test_rule_set_builder.rb
@@ -46,6 +46,16 @@ class TestRuleSetBuilder < Test::Unit::TestCase
     assert_equal(expected, actual)
   end
 
+  def test_build_all_rulesets_config_abstract_rule_changed
+    diff_filenames = <<~DOC
+      pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaRulechainRule.java
+    DOC
+    mock_build?(diff_filenames, nil, "#{PATH_TO_TEST_RESOURCES}/patch-ruleset.xml")
+
+    assert(!File.exist?(RuleSetBuilder::PATH_TO_DYNAMIC_CONFIG),
+           "File #{RuleSetBuilder::PATH_TO_DYNAMIC_CONFIG} must not exist")
+  end
+
   def test_build_all_rulesets_config
     diff_filenames = <<~DOC
       pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java


### PR DESCRIPTION
Since I ran into this twice in short succession, I figured I might just as well fix this.

Applies a simple heuristic: If the name of a rule starts with 'Abstract', it's an abstract class. This could change any number of rules, so let's bail and just compare all rules.

My knowledge of ruby is very basic. I basically copied one of the other "compare all rules" test cases.

Fixes #124 